### PR TITLE
internal/binding: enable unnamed struct fields when parsing

### DIFF
--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -320,7 +320,7 @@ func (d *Declaration) Parameters() []Parameter {
 	return p
 }
 
-// Declarations returns the C function declarations in the givel set of file paths.
+// Declarations returns the C function declarations in the given set of file paths.
 func Declarations(paths ...string) ([]Declaration, error) {
 	predefined, includePaths, sysIncludePaths, err := cc.HostConfig()
 	if err != nil {

--- a/internal/binding/binding.go
+++ b/internal/binding/binding.go
@@ -341,6 +341,7 @@ unsigned long long __builtin_bswap64 (unsigned long long x);
 		model(),
 		cc.IncludePaths(includePaths),
 		cc.SysIncludePaths(sysIncludePaths),
+		cc.EnableAnonymousStructFields(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("binding: failed to parse %q: %v", paths, err)


### PR DESCRIPTION
This avoids an error on Fedora 27.