### PR TITLE
travis: fix build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ go:
  - 1.9.x
  - master
 
-matrix:
- fast_finish: true
- allow_failures:
-   - go: master
-
 go_import_path: gonum.org/v1/netlib
 
 os:
@@ -30,6 +25,9 @@ env:
   #- BLAS_LIB=Accellerate
 
 matrix:
+ fast_finish: true
+ allow_failures:
+   - go: master
  exclude:
   - os: linux
     env: BLAS_LIB=Accelerate
@@ -47,7 +45,7 @@ cache:
 
 # Install the appropriate blas library (if any) and associated gonum software.
 install:
- - source ${TRAVIS_BUILD_DIR}/.travis/$TRAVIS_OS_NAME/$BLAS_LIB/install.sh
+ - travis_wait 20 source ${TRAVIS_BUILD_DIR}/.travis/$TRAVIS_OS_NAME/$BLAS_LIB/install.sh
 
 script:
  - source ${TRAVIS_BUILD_DIR}/.travis/$TRAVIS_OS_NAME/$BLAS_LIB/test.sh

--- a/.travis/linux/OpenBLAS/install.sh
+++ b/.travis/linux/OpenBLAS/install.sh
@@ -29,6 +29,7 @@ if [ ! -e ${CACHE_DIR}/last_commit_id ]; then
     sudo git clone --depth=1 git://github.com/xianyi/OpenBLAS
 
     pushd OpenBLAS
+    echo OpenBLAS version:$(git rev-parse HEAD)
     sudo make FC=gfortran &> /dev/null && sudo make PREFIX=${CACHE_DIR} install
     popd
 	

--- a/.travis/linux/OpenBLAS/test.sh
+++ b/.travis/linux/OpenBLAS/test.sh
@@ -2,6 +2,7 @@ set -ex
 
 go env
 go get -d -t -v ./...
+export CGO_LDFLAGS="-L/usr/lib -lopenblas"
 go test -a -v ./...
 if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then bash -c "$GOPATH/src/gonum.org/v1/netlib/.travis/test-coverage.sh"; fi
 

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -2541,6 +2541,11 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	C.cblas_zgbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.int(kL), C.int(kU), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
 
+// Ztrmv performs one of the matrix-vector operations
+//  x = A * x    if trans = blas.NoTrans
+//  x = A^T * x  if trans = blas.Trans
+//  x = A^H * x  if trans = blas.ConjTrans
+// where x is a vector, and A is an n×n triangular matrix.
 func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:280:6 void cblas_ztrmv ...
 
@@ -2652,6 +2657,17 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	C.cblas_ztpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX))
 }
 
+// Ztrsv solves one of the systems of equations
+//  A*x = b     if trans == blas.NoTrans,
+//  A^T*x = b,  if trans == blas.Trans,
+//  A^H*x = b,  if trans == blas.ConjTrans,
+// where b and x are n element vectors and A is an n×n triangular matrix.
+//
+// On entry, x contains the values of b, and the solution is
+// stored in-place into x.
+//
+// No test for singularity or near-singularity is included in this
+// routine. Such tests must be performed before calling this routine.
 func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:291:6 void cblas_ztrsv ...
 


### PR DESCRIPTION
We have been seeing no-output time outs for OpenBLAS recently. This is an attempt to mitigate that.

During looking at the process I noticed that we don't seem to output the OpenBLAS sha1 anymore, the second commit restores that behaviour.

Finally, it appears that travis-ci have changed how they are shelling things and setting CGO_LDFLAGS only once at the site of install does not impact on the env of the go test invocation, so it is added there in the third commit.

Please take a look.