### PR TITLE
lapack/netlib: relax requirement on work length in Dbdsqr

### DIFF
--- a/lapack/netlib/lapack.go
+++ b/lapack/netlib/lapack.go
@@ -824,7 +824,7 @@ func (impl Implementation) Dgebak(job lapack.Job, side lapack.EVSide, n, ilo, ih
 // C is a matrix of size n×ncc whose elements are stored in c. The elements
 // of c are modified to contain Q^T * C on exit. C is not used if ncc == 0.
 //
-// work contains temporary storage and must have length at least 4*n. Dbdsqr
+// work contains temporary storage and must have length at least 4*(n-1). Dbdsqr
 // will panic if there is insufficient working memory.
 //
 // Dbdsqr returns whether the decomposition was successful.
@@ -847,7 +847,7 @@ func (impl Implementation) Dbdsqr(uplo blas.Uplo, n, ncvt, nru, ncc int, d, e, v
 	if len(e) < n-1 {
 		panic(badE)
 	}
-	if len(work) < 4*n {
+	if len(work) < 4*(n-1) {
 		panic(badWork)
 	}
 	// An address must be passed to cgo. If lengths are zero, allocate a slice.


### PR DESCRIPTION
Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
