### PR TITLE
blas/netlib: use panic string consts instead of string literals

### DIFF
--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -1346,6 +1346,9 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(m-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -1357,9 +1360,6 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(m-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1418,6 +1418,9 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -1429,9 +1432,6 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1493,11 +1493,11 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1558,11 +1558,11 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1685,11 +1685,11 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1757,11 +1757,11 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1874,6 +1874,9 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(m-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -1885,9 +1888,6 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(m-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -1946,6 +1946,9 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -1957,9 +1960,6 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2021,11 +2021,11 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2086,11 +2086,11 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2213,11 +2213,11 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2285,11 +2285,11 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2398,6 +2398,9 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(m-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2409,9 +2412,6 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(m-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2465,6 +2465,9 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2476,9 +2479,6 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2536,11 +2536,11 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2597,11 +2597,11 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2710,11 +2710,11 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2771,11 +2771,11 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2879,6 +2879,9 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(m-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2890,9 +2893,6 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(m-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -2952,6 +2952,9 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if m == 0 || n == 0 {
 		return
 	}
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2963,9 +2966,6 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	}
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3028,11 +3028,11 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3095,11 +3095,11 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3225,11 +3225,11 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3298,11 +3298,11 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
 	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3412,14 +3412,14 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -3469,14 +3469,14 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+k+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+k+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -3659,11 +3659,11 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3756,14 +3756,14 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3810,14 +3810,14 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -3867,14 +3867,14 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+k+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+k+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -4057,11 +4057,11 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4154,14 +4154,14 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4204,14 +4204,14 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -4257,14 +4257,14 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+k+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+k+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -4478,11 +4478,11 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4568,14 +4568,14 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4623,14 +4623,14 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+n > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+n > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -4681,14 +4681,14 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if n == 0 {
 		return
 	}
+	if lda*(n-1)+k+1 > len(a) {
+		panic("blas: index of a out of range")
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
-	}
-	if lda*(n-1)+k+1 > len(a) {
-		panic("blas: index of a out of range")
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -4925,11 +4925,11 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -5025,14 +5025,14 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
-		panic("blas: index of ap out of range")
-	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
+	}
+	if n*(n+1)/2 > len(ap) {
+		panic("blas: index of ap out of range")
 	}
 	var _x *complex128
 	if len(x) > 0 {

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -82,9 +82,13 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
 		panic(badFlag)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -127,9 +131,13 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
 		panic(badFlag)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -160,9 +168,13 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -190,9 +202,13 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -220,9 +236,13 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -250,9 +270,13 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -287,9 +311,13 @@ func (Implementation) Sdsdot(n int, alpha float32, x []float32, incX int, y []fl
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -321,9 +349,13 @@ func (Implementation) Dsdot(n int, x []float32, incX int, y []float32, incY int)
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -355,9 +387,13 @@ func (Implementation) Sdot(n int, x []float32, incX int, y []float32, incY int) 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -389,9 +425,13 @@ func (Implementation) Ddot(n int, x []float64, incX int, y []float64, incY int) 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -421,9 +461,13 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -446,9 +490,13 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -471,9 +519,13 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -496,9 +548,13 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -518,9 +574,13 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -540,9 +600,13 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -565,9 +629,13 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -590,9 +658,13 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -615,9 +687,13 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return -1
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -640,9 +716,13 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return -1
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -662,9 +742,13 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return -1
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -686,9 +770,13 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return -1
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -713,9 +801,13 @@ func (Implementation) Sswap(n int, x []float32, incX int, y []float32, incY int)
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -747,9 +839,13 @@ func (Implementation) Scopy(n int, x []float32, incX int, y []float32, incY int)
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -781,9 +877,13 @@ func (Implementation) Saxpy(n int, alpha float32, x []float32, incX int, y []flo
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -815,9 +915,13 @@ func (Implementation) Dswap(n int, x []float64, incX int, y []float64, incY int)
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -849,9 +953,13 @@ func (Implementation) Dcopy(n int, x []float64, incX int, y []float64, incY int)
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -883,9 +991,13 @@ func (Implementation) Daxpy(n int, alpha float64, x []float64, incX int, y []flo
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -915,9 +1027,13 @@ func (Implementation) Cswap(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -947,9 +1063,13 @@ func (Implementation) Ccopy(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -979,9 +1099,13 @@ func (Implementation) Caxpy(n int, alpha complex64, x []complex64, incX int, y [
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1012,9 +1136,13 @@ func (Implementation) Zswap(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1045,9 +1173,13 @@ func (Implementation) Zcopy(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1079,9 +1211,13 @@ func (Implementation) Zaxpy(n int, alpha complex128, x []complex128, incX int, y
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1114,9 +1250,13 @@ func (Implementation) Srot(n int, x []float32, incX int, y []float32, incY int, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1149,9 +1289,13 @@ func (Implementation) Drot(n int, x []float64, incX int, y []float64, incY int, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1181,9 +1325,13 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1206,9 +1354,13 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1228,9 +1380,13 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1252,9 +1408,13 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1274,9 +1434,13 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1298,9 +1462,13 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(x) <= (n-1)*incX {
 		panic(shortX)
 	}
@@ -1343,9 +1511,13 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(m-1)+n {
 		panic(shortA)
 	}
@@ -1415,9 +1587,13 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic(shortA)
 	}
@@ -1490,9 +1666,13 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -1555,9 +1735,13 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -1614,9 +1798,13 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -1682,9 +1870,13 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -1754,9 +1946,13 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -1819,9 +2015,13 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -1871,9 +2071,13 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(m-1)+n {
 		panic(shortA)
 	}
@@ -1943,9 +2147,13 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic(shortA)
 	}
@@ -2018,9 +2226,13 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -2083,9 +2295,13 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -2142,9 +2358,13 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -2210,9 +2430,13 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -2282,9 +2506,13 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -2347,9 +2575,13 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -2395,9 +2627,13 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(m-1)+n {
 		panic(shortA)
 	}
@@ -2462,9 +2698,13 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic(shortA)
 	}
@@ -2533,9 +2773,13 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -2594,9 +2838,13 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -2649,9 +2897,13 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -2707,9 +2959,13 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -2768,9 +3024,13 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -2823,9 +3083,13 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -2876,9 +3140,13 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(m-1)+n {
 		panic(shortA)
 	}
@@ -2949,9 +3217,13 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic(shortA)
 	}
@@ -3025,9 +3297,13 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -3092,9 +3368,13 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -3153,9 +3433,13 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -3222,9 +3506,13 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -3295,9 +3583,13 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -3362,9 +3654,13 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -3409,9 +3705,13 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -3466,9 +3766,13 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -3517,9 +3821,13 @@ func (Implementation) Sspmv(ul blas.Uplo, n int, alpha float32, ap, x []float32,
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -3565,9 +3873,13 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -3615,9 +3927,13 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -3656,9 +3972,13 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -3702,9 +4022,13 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -3753,9 +4077,13 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -3807,9 +4135,13 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -3864,9 +4196,13 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -3915,9 +4251,13 @@ func (Implementation) Dspmv(ul blas.Uplo, n int, alpha float64, ap, x []float64,
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -3963,9 +4303,13 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -4013,9 +4357,13 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4054,9 +4402,13 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4100,9 +4452,13 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4151,9 +4507,13 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4201,9 +4561,13 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -4254,9 +4618,13 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -4301,9 +4669,13 @@ func (Implementation) Chpmv(ul blas.Uplo, n int, alpha complex64, ap, x []comple
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -4346,9 +4718,13 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -4391,9 +4767,13 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -4438,9 +4818,13 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4475,9 +4859,13 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4518,9 +4906,13 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4565,9 +4957,13 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4620,9 +5016,13 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+n {
 		panic(shortA)
 	}
@@ -4678,9 +5078,13 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(n-1)+k+1 {
 		panic(shortA)
 	}
@@ -4730,9 +5134,13 @@ func (Implementation) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap, x []compl
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(ap) < n*(n+1)/2 {
 		panic(shortAP)
 	}
@@ -4779,9 +5187,13 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -4828,9 +5240,13 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic(shortX)
 	}
@@ -4880,9 +5296,13 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4922,9 +5342,13 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if incX == 0 {
 		panic(zeroIncX)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -4970,9 +5394,13 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -5022,9 +5450,13 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -5109,9 +5541,13 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(rowA-1)+colA {
 		panic(shortA)
 	}
@@ -5181,9 +5617,13 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -5252,9 +5692,13 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -5319,9 +5763,13 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -5407,9 +5855,13 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -5494,9 +5946,13 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -5574,9 +6030,13 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(rowA-1)+colA {
 		panic(shortA)
 	}
@@ -5646,9 +6106,13 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -5717,9 +6181,13 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -5784,9 +6252,13 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -5872,9 +6344,13 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -5959,9 +6435,13 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6031,9 +6511,13 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(rowA-1)+colA {
 		panic(shortA)
 	}
@@ -6098,9 +6582,13 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6162,9 +6650,13 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -6222,9 +6714,13 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -6304,9 +6800,13 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6379,9 +6879,13 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6451,9 +6955,13 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(rowA-1)+colA {
 		panic(shortA)
 	}
@@ -6518,9 +7026,13 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6582,9 +7094,13 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -6642,9 +7158,13 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -6724,9 +7244,13 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6799,9 +7323,13 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic(badLdB)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6859,9 +7387,13 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -6923,9 +7455,13 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -6983,9 +7519,13 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -7050,9 +7590,13 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(k-1)+k {
 		panic(shortA)
 	}
@@ -7114,9 +7658,13 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -7174,9 +7722,13 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc < max(1, n) {
 		panic(badLdC)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -71,25 +71,25 @@ func (Implementation) Srotmg(d1 float32, d2 float32, b1 float32, b2 float32) (p 
 }
 func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int, p blas.SrotmParams) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+		panic(badFlag)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -116,25 +116,25 @@ func (Implementation) Drotmg(d1 float64, d2 float64, b1 float64, b2 float64) (p 
 }
 func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int, p blas.DrotmParams) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+		panic(badFlag)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -152,22 +152,22 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 }
 func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY int) (dotu complex64) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -182,22 +182,22 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 }
 func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY int) (dotc complex64) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -212,22 +212,22 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 }
 func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, incY int) (dotu complex128) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -242,22 +242,22 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 }
 func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, incY int) (dotc complex128) {
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -279,22 +279,22 @@ func (Implementation) Sdsdot(n int, alpha float32, x []float32, incX int, y []fl
 	// declared at cblas.h:24:8 float cblas_sdsdot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -313,22 +313,22 @@ func (Implementation) Dsdot(n int, x []float32, incX int, y []float32, incY int)
 	// declared at cblas.h:26:8 double cblas_dsdot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -347,22 +347,22 @@ func (Implementation) Sdot(n int, x []float32, incX int, y []float32, incY int) 
 	// declared at cblas.h:28:8 float cblas_sdot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -381,22 +381,22 @@ func (Implementation) Ddot(n int, x []float64, incX int, y []float64, incY int) 
 	// declared at cblas.h:30:8 double cblas_ddot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return 0
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -416,16 +416,16 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	// declared at cblas.h:49:8 float cblas_snrm2 ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -441,16 +441,16 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	// declared at cblas.h:50:8 float cblas_sasum ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -466,16 +466,16 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	// declared at cblas.h:52:8 double cblas_dnrm2 ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -491,16 +491,16 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	// declared at cblas.h:53:8 double cblas_dasum ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -513,16 +513,16 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	// declared at cblas.h:55:8 float cblas_scnrm2 ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -535,16 +535,16 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	// declared at cblas.h:56:8 float cblas_scasum ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -560,16 +560,16 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	// declared at cblas.h:58:8 double cblas_dznrm2 ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -585,16 +585,16 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	// declared at cblas.h:59:8 double cblas_dzasum ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return 0
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -610,16 +610,16 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	// declared at cblas.h:65:13 int cblas_isamax ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -635,16 +635,16 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	// declared at cblas.h:66:13 int cblas_idamax ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -657,16 +657,16 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	// declared at cblas.h:67:13 int cblas_icamax ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -681,16 +681,16 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	// declared at cblas.h:68:13 int cblas_izamax ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -705,22 +705,22 @@ func (Implementation) Sswap(n int, x []float32, incX int, y []float32, incY int)
 	// declared at cblas.h:79:6 void cblas_sswap ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -739,22 +739,22 @@ func (Implementation) Scopy(n int, x []float32, incX int, y []float32, incY int)
 	// declared at cblas.h:81:6 void cblas_scopy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -773,22 +773,22 @@ func (Implementation) Saxpy(n int, alpha float32, x []float32, incX int, y []flo
 	// declared at cblas.h:83:6 void cblas_saxpy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -807,22 +807,22 @@ func (Implementation) Dswap(n int, x []float64, incX int, y []float64, incY int)
 	// declared at cblas.h:90:6 void cblas_dswap ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -841,22 +841,22 @@ func (Implementation) Dcopy(n int, x []float64, incX int, y []float64, incY int)
 	// declared at cblas.h:92:6 void cblas_dcopy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -875,22 +875,22 @@ func (Implementation) Daxpy(n int, alpha float64, x []float64, incX int, y []flo
 	// declared at cblas.h:94:6 void cblas_daxpy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -907,22 +907,22 @@ func (Implementation) Cswap(n int, x []complex64, incX int, y []complex64, incY 
 	// declared at cblas.h:101:6 void cblas_cswap ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -939,22 +939,22 @@ func (Implementation) Ccopy(n int, x []complex64, incX int, y []complex64, incY 
 	// declared at cblas.h:103:6 void cblas_ccopy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -971,22 +971,22 @@ func (Implementation) Caxpy(n int, alpha complex64, x []complex64, incX int, y [
 	// declared at cblas.h:105:6 void cblas_caxpy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -1004,22 +1004,22 @@ func (Implementation) Zswap(n int, x []complex128, incX int, y []complex128, inc
 	// declared at cblas.h:112:6 void cblas_zswap ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -1037,22 +1037,22 @@ func (Implementation) Zcopy(n int, x []complex128, incX int, y []complex128, inc
 	// declared at cblas.h:114:6 void cblas_zcopy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -1071,22 +1071,22 @@ func (Implementation) Zaxpy(n int, alpha complex128, x []complex128, incX int, y
 	// declared at cblas.h:116:6 void cblas_zaxpy ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -1106,22 +1106,22 @@ func (Implementation) Srot(n int, x []float32, incX int, y []float32, incY int, 
 	// declared at cblas.h:129:6 void cblas_srot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -1141,22 +1141,22 @@ func (Implementation) Drot(n int, x []float64, incX int, y []float64, incY int, 
 	// declared at cblas.h:136:6 void cblas_drot ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -1176,16 +1176,16 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	// declared at cblas.h:145:6 void cblas_sscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -1201,16 +1201,16 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	// declared at cblas.h:146:6 void cblas_dscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -1223,16 +1223,16 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	// declared at cblas.h:147:6 void cblas_cscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -1247,16 +1247,16 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	// declared at cblas.h:148:6 void cblas_zscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -1269,16 +1269,16 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	// declared at cblas.h:149:6 void cblas_csscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -1293,16 +1293,16 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	// declared at cblas.h:150:6 void cblas_zdscal ...
 
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 || incX < 0 {
 		return
 	}
 	if len(x) <= (n-1)*incX {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -1326,28 +1326,28 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1356,10 +1356,10 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1392,34 +1392,34 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if kL < 0 {
-		panic("blas: kL < 0")
+		panic(kLLT0)
 	}
 	if kU < 0 {
-		panic("blas: kU < 0")
+		panic(kULT0)
 	}
 	if lda < kL+kU+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1428,10 +1428,10 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1463,7 +1463,7 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1471,7 +1471,7 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1479,25 +1479,25 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1525,7 +1525,7 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1533,7 +1533,7 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1541,28 +1541,28 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1590,7 +1590,7 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1598,7 +1598,7 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1606,22 +1606,22 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -1655,7 +1655,7 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1663,7 +1663,7 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1671,25 +1671,25 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1724,7 +1724,7 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1732,7 +1732,7 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1740,28 +1740,28 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -1795,7 +1795,7 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1803,7 +1803,7 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1811,22 +1811,22 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -1854,28 +1854,28 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1884,10 +1884,10 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -1920,34 +1920,34 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if kL < 0 {
-		panic("blas: kL < 0")
+		panic(kLLT0)
 	}
 	if kU < 0 {
-		panic("blas: kU < 0")
+		panic(kULT0)
 	}
 	if lda < kL+kU+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1956,10 +1956,10 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -1991,7 +1991,7 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -1999,7 +1999,7 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2007,25 +2007,25 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2053,7 +2053,7 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2061,7 +2061,7 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2069,28 +2069,28 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2118,7 +2118,7 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2126,7 +2126,7 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2134,22 +2134,22 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -2183,7 +2183,7 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2191,7 +2191,7 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2199,25 +2199,25 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2252,7 +2252,7 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2260,7 +2260,7 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2268,28 +2268,28 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -2323,7 +2323,7 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2331,7 +2331,7 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2339,22 +2339,22 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -2378,28 +2378,28 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2408,10 +2408,10 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2439,34 +2439,34 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if kL < 0 {
-		panic("blas: kL < 0")
+		panic(kLLT0)
 	}
 	if kU < 0 {
-		panic("blas: kU < 0")
+		panic(kULT0)
 	}
 	if lda < kL+kU+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2475,10 +2475,10 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2506,7 +2506,7 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2514,7 +2514,7 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2522,25 +2522,25 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2564,7 +2564,7 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2572,7 +2572,7 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2580,28 +2580,28 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2625,7 +2625,7 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2633,7 +2633,7 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2641,22 +2641,22 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -2680,7 +2680,7 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2688,7 +2688,7 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2696,25 +2696,25 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2738,7 +2738,7 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2746,7 +2746,7 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2754,28 +2754,28 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -2799,7 +2799,7 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -2807,7 +2807,7 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2815,22 +2815,22 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -2859,28 +2859,28 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2889,10 +2889,10 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -2926,34 +2926,34 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if kL < 0 {
-		panic("blas: kL < 0")
+		panic(kLLT0)
 	}
 	if kU < 0 {
-		panic("blas: kU < 0")
+		panic(kULT0)
 	}
 	if lda < kL+kU+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2962,10 +2962,10 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 		lenX, lenY = m, n
 	}
 	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -2998,7 +2998,7 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3006,7 +3006,7 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3014,25 +3014,25 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3062,7 +3062,7 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3070,7 +3070,7 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3078,28 +3078,28 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3129,7 +3129,7 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3137,7 +3137,7 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3145,22 +3145,22 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -3195,7 +3195,7 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3203,7 +3203,7 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3211,25 +3211,25 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3265,7 +3265,7 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3273,7 +3273,7 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3281,28 +3281,28 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -3338,7 +3338,7 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -3346,7 +3346,7 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3354,22 +3354,22 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -3395,31 +3395,31 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -3449,34 +3449,34 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -3506,28 +3506,28 @@ func (Implementation) Sspmv(ul blas.Uplo, n int, alpha float32, ap, x []float32,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -3551,31 +3551,31 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	// declared at cblas.h:319:6 void cblas_sger ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3604,25 +3604,25 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3648,22 +3648,22 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3688,31 +3688,31 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3742,28 +3742,28 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *float32
 	if len(x) > 0 {
@@ -3793,31 +3793,31 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -3847,34 +3847,34 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -3904,28 +3904,28 @@ func (Implementation) Dspmv(ul blas.Uplo, n int, alpha float64, ap, x []float64,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -3949,31 +3949,31 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	// declared at cblas.h:348:6 void cblas_dger ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4002,25 +4002,25 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4046,22 +4046,22 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4086,31 +4086,31 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4140,28 +4140,28 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *float64
 	if len(x) > 0 {
@@ -4187,31 +4187,31 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -4237,34 +4237,34 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -4290,28 +4290,28 @@ func (Implementation) Chpmv(ul blas.Uplo, n int, alpha complex64, ap, x []comple
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -4332,31 +4332,31 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	// declared at cblas.h:381:6 void cblas_cgeru ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4377,31 +4377,31 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	// declared at cblas.h:384:6 void cblas_cgerc ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4427,25 +4427,25 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4467,22 +4467,22 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4504,31 +4504,31 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4554,28 +4554,28 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *complex64
 	if len(x) > 0 {
@@ -4606,31 +4606,31 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -4661,34 +4661,34 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	if lda < k+1 {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(n-1)+k+1 {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -4719,28 +4719,28 @@ func (Implementation) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap, x []compl
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -4765,31 +4765,31 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	// declared at cblas.h:412:6 void cblas_zgeru ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -4814,31 +4814,31 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	// declared at cblas.h:415:6 void cblas_zgerc ...
 
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(m-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -4869,25 +4869,25 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -4914,22 +4914,22 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -4956,31 +4956,31 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if lda < max(1, n) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(a) < lda*(n-1)+n {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -5011,28 +5011,28 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if incX == 0 {
-		panic("blas: zero x index increment")
+		panic(zeroIncX)
 	}
 	if incY == 0 {
-		panic("blas: zero y index increment")
+		panic(zeroIncY)
 	}
 	if n == 0 {
 		return
 	}
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
-		panic("blas: x index out of range")
+		panic(shortX)
 	}
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
-		panic("blas: y index out of range")
+		panic(shortY)
 	}
 	if len(ap) < n*(n+1)/2 {
-		panic("blas: index of ap out of range")
+		panic(shortAP)
 	}
 	var _x *complex128
 	if len(x) > 0 {
@@ -5068,7 +5068,7 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch tB {
 	case blas.NoTrans:
@@ -5078,16 +5078,16 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	case blas.ConjTrans:
 		tB = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
@@ -5101,25 +5101,25 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 		rowB, colB = n, k
 	}
 	if lda < max(1, colA) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, colB) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(rowA-1)+colA {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(rowB-1)+colB {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5150,7 +5150,7 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -5158,13 +5158,13 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5173,25 +5173,25 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5224,7 +5224,7 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5232,13 +5232,13 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5247,19 +5247,19 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5288,7 +5288,7 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5296,13 +5296,13 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5311,25 +5311,25 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5363,7 +5363,7 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5371,7 +5371,7 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -5379,7 +5379,7 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -5387,13 +5387,13 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5402,19 +5402,19 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5450,7 +5450,7 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5458,7 +5458,7 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -5466,7 +5466,7 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -5474,13 +5474,13 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5489,19 +5489,19 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *float32
 	if len(a) > 0 {
@@ -5533,7 +5533,7 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch tB {
 	case blas.NoTrans:
@@ -5543,16 +5543,16 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	case blas.ConjTrans:
 		tB = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
@@ -5566,25 +5566,25 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 		rowB, colB = n, k
 	}
 	if lda < max(1, colA) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, colB) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(rowA-1)+colA {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(rowB-1)+colB {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5615,7 +5615,7 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -5623,13 +5623,13 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5638,25 +5638,25 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5689,7 +5689,7 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5697,13 +5697,13 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5712,19 +5712,19 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5753,7 +5753,7 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5761,13 +5761,13 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5776,25 +5776,25 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5828,7 +5828,7 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5836,7 +5836,7 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -5844,7 +5844,7 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -5852,13 +5852,13 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5867,19 +5867,19 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5915,7 +5915,7 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -5923,7 +5923,7 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -5931,7 +5931,7 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -5939,13 +5939,13 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5954,19 +5954,19 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *float64
 	if len(a) > 0 {
@@ -5990,7 +5990,7 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch tB {
 	case blas.NoTrans:
@@ -6000,16 +6000,16 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	case blas.ConjTrans:
 		tB = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
@@ -6023,25 +6023,25 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 		rowB, colB = n, k
 	}
 	if lda < max(1, colA) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, colB) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(rowA-1)+colA {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(rowB-1)+colB {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6067,7 +6067,7 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -6075,13 +6075,13 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6090,25 +6090,25 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6134,7 +6134,7 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	case blas.Trans:
 		t = C.CblasTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6142,13 +6142,13 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6157,19 +6157,19 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6191,7 +6191,7 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Trans:
 		t = C.CblasTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6199,13 +6199,13 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6214,25 +6214,25 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6260,7 +6260,7 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6268,7 +6268,7 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -6276,7 +6276,7 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -6284,13 +6284,13 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6299,19 +6299,19 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6335,7 +6335,7 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6343,7 +6343,7 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -6351,7 +6351,7 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -6359,13 +6359,13 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6374,19 +6374,19 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6410,7 +6410,7 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch tB {
 	case blas.NoTrans:
@@ -6420,16 +6420,16 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	case blas.ConjTrans:
 		tB = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
@@ -6443,25 +6443,25 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 		rowB, colB = n, k
 	}
 	if lda < max(1, colA) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, colB) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(rowA-1)+colA {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(rowB-1)+colB {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6487,7 +6487,7 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -6495,13 +6495,13 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6510,25 +6510,25 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6554,7 +6554,7 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	case blas.Trans:
 		t = C.CblasTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6562,13 +6562,13 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6577,19 +6577,19 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6611,7 +6611,7 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Trans:
 		t = C.CblasTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6619,13 +6619,13 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6634,25 +6634,25 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6680,7 +6680,7 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6688,7 +6688,7 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -6696,7 +6696,7 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -6704,13 +6704,13 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6719,19 +6719,19 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6755,7 +6755,7 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.ConjTrans:
 		tA = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6763,7 +6763,7 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch d {
 	case blas.NonUnit:
@@ -6771,7 +6771,7 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Unit:
 		d = C.CblasUnit
 	default:
-		panic("blas: illegal diagonal")
+		panic(badDiag)
 	}
 	switch s {
 	case blas.Left:
@@ -6779,13 +6779,13 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6794,19 +6794,19 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -6828,7 +6828,7 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -6836,13 +6836,13 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6851,25 +6851,25 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6895,7 +6895,7 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6903,13 +6903,13 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6918,19 +6918,19 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -6952,7 +6952,7 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -6960,13 +6960,13 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6975,25 +6975,25 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex64
 	if len(a) > 0 {
@@ -7019,7 +7019,7 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	switch s {
 	case blas.Left:
@@ -7027,13 +7027,13 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	case blas.Right:
 		s = C.CblasRight
 	default:
-		panic("blas: illegal side")
+		panic(badSide)
 	}
 	if m < 0 {
-		panic("blas: m < 0")
+		panic(mLT0)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -7042,25 +7042,25 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 		k = n
 	}
 	if lda < max(1, k) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, n) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if m == 0 || n == 0 {
 		return
 	}
 	if len(a) < lda*(k-1)+k {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(m-1)+n {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(m-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -7086,7 +7086,7 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -7094,13 +7094,13 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -7109,19 +7109,19 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {
@@ -7143,7 +7143,7 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.ConjTrans:
 		t = C.CblasConjTrans
 	default:
-		panic("blas: illegal transpose")
+		panic(badTranspose)
 	}
 	switch ul {
 	case blas.Upper:
@@ -7151,13 +7151,13 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	case blas.Lower:
 		ul = C.CblasLower
 	default:
-		panic("blas: illegal triangle")
+		panic(badUplo)
 	}
 	if n < 0 {
-		panic("blas: n < 0")
+		panic(nLT0)
 	}
 	if k < 0 {
-		panic("blas: k < 0")
+		panic(kLT0)
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -7166,25 +7166,25 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 		row, col = k, n
 	}
 	if lda < max(1, col) {
-		panic("blas: bad lda")
+		panic(badLdA)
 	}
 	if ldb < max(1, col) {
-		panic("blas: bad ldb")
+		panic(badLdB)
 	}
 	if ldc < max(1, n) {
-		panic("blas: bad ldc")
+		panic(badLdC)
 	}
 	if n == 0 {
 		return
 	}
 	if len(a) < lda*(row-1)+col {
-		panic("blas: index of a out of range")
+		panic(shortA)
 	}
 	if len(b) < ldb*(row-1)+col {
-		panic("blas: index of b out of range")
+		panic(shortB)
 	}
 	if len(c) < ldc*(n-1)+n {
-		panic("blas: index of c out of range")
+		panic(shortC)
 	}
 	var _a *complex128
 	if len(a) > 0 {

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -281,19 +281,14 @@ func (Implementation) Sdsdot(n int, alpha float32, x []float32, incX int, y []fl
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -301,8 +296,13 @@ func (Implementation) Sdsdot(n int, alpha float32, x []float32, incX int, y []fl
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	return float32(C.cblas_sdsdot(C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY)))
 }
@@ -315,19 +315,14 @@ func (Implementation) Dsdot(n int, x []float32, incX int, y []float32, incY int)
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -335,8 +330,13 @@ func (Implementation) Dsdot(n int, x []float32, incX int, y []float32, incY int)
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	return float64(C.cblas_dsdot(C.int(n), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY)))
 }
@@ -349,19 +349,14 @@ func (Implementation) Sdot(n int, x []float32, incX int, y []float32, incY int) 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -369,8 +364,13 @@ func (Implementation) Sdot(n int, x []float32, incX int, y []float32, incY int) 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	return float32(C.cblas_sdot(C.int(n), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY)))
 }
@@ -383,19 +383,14 @@ func (Implementation) Ddot(n int, x []float64, incX int, y []float64, incY int) 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -403,8 +398,13 @@ func (Implementation) Ddot(n int, x []float64, incX int, y []float64, incY int) 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	return float64(C.cblas_ddot(C.int(n), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY)))
 }
@@ -418,12 +418,11 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -431,8 +430,9 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float32(C.cblas_snrm2(C.int(n), (*C.float)(_x), C.int(incX)))
 }
@@ -446,12 +446,11 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -459,8 +458,9 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float32(C.cblas_sasum(C.int(n), (*C.float)(_x), C.int(incX)))
 }
@@ -474,12 +474,11 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -487,8 +486,9 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float64(C.cblas_dnrm2(C.int(n), (*C.double)(_x), C.int(incX)))
 }
@@ -502,12 +502,11 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -515,8 +514,9 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float64(C.cblas_dasum(C.int(n), (*C.double)(_x), C.int(incX)))
 }
@@ -527,12 +527,11 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -540,8 +539,9 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float32(C.cblas_scnrm2(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -552,12 +552,11 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -565,8 +564,9 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float32(C.cblas_scasum(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -580,12 +580,11 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -593,8 +592,9 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float64(C.cblas_dznrm2(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -608,12 +608,11 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if incX < 0 {
 		return 0
@@ -621,8 +620,9 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return float64(C.cblas_dzasum(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -636,12 +636,11 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return -1
 	}
 	if n == 0 || incX < 0 {
 		return -1
@@ -649,8 +648,9 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return -1
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return int(C.cblas_isamax(C.int(n), (*C.float)(_x), C.int(incX)))
 }
@@ -664,12 +664,11 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return -1
 	}
 	if n == 0 || incX < 0 {
 		return -1
@@ -677,8 +676,9 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return -1
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return int(C.cblas_idamax(C.int(n), (*C.double)(_x), C.int(incX)))
 }
@@ -689,12 +689,11 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return -1
 	}
 	if n == 0 || incX < 0 {
 		return -1
@@ -702,8 +701,9 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return -1
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return int(C.cblas_icamax(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -716,12 +716,11 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return -1
 	}
 	if n == 0 || incX < 0 {
 		return -1
@@ -729,8 +728,9 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return -1
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	return int(C.cblas_izamax(C.int(n), unsafe.Pointer(_x), C.int(incX)))
 }
@@ -743,19 +743,14 @@ func (Implementation) Sswap(n int, x []float32, incX int, y []float32, incY int)
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -763,8 +758,13 @@ func (Implementation) Sswap(n int, x []float32, incX int, y []float32, incY int)
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_sswap(C.int(n), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY))
 }
@@ -777,19 +777,14 @@ func (Implementation) Scopy(n int, x []float32, incX int, y []float32, incY int)
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -797,8 +792,13 @@ func (Implementation) Scopy(n int, x []float32, incX int, y []float32, incY int)
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_scopy(C.int(n), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY))
 }
@@ -811,19 +811,14 @@ func (Implementation) Saxpy(n int, alpha float32, x []float32, incX int, y []flo
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -831,8 +826,13 @@ func (Implementation) Saxpy(n int, alpha float32, x []float32, incX int, y []flo
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_saxpy(C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY))
 }
@@ -845,19 +845,14 @@ func (Implementation) Dswap(n int, x []float64, incX int, y []float64, incY int)
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -865,8 +860,13 @@ func (Implementation) Dswap(n int, x []float64, incX int, y []float64, incY int)
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_dswap(C.int(n), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY))
 }
@@ -879,19 +879,14 @@ func (Implementation) Dcopy(n int, x []float64, incX int, y []float64, incY int)
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -899,8 +894,13 @@ func (Implementation) Dcopy(n int, x []float64, incX int, y []float64, incY int)
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_dcopy(C.int(n), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY))
 }
@@ -913,19 +913,14 @@ func (Implementation) Daxpy(n int, alpha float64, x []float64, incX int, y []flo
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -933,8 +928,13 @@ func (Implementation) Daxpy(n int, alpha float64, x []float64, incX int, y []flo
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_daxpy(C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY))
 }
@@ -945,19 +945,14 @@ func (Implementation) Cswap(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -965,8 +960,13 @@ func (Implementation) Cswap(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cswap(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -977,19 +977,14 @@ func (Implementation) Ccopy(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -997,8 +992,13 @@ func (Implementation) Ccopy(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_ccopy(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -1009,19 +1009,14 @@ func (Implementation) Caxpy(n int, alpha complex64, x []complex64, incX int, y [
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1029,8 +1024,13 @@ func (Implementation) Caxpy(n int, alpha complex64, x []complex64, incX int, y [
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_caxpy(C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -1042,19 +1042,14 @@ func (Implementation) Zswap(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1062,8 +1057,13 @@ func (Implementation) Zswap(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zswap(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -1075,19 +1075,14 @@ func (Implementation) Zcopy(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1095,8 +1090,13 @@ func (Implementation) Zcopy(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zcopy(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -1109,19 +1109,14 @@ func (Implementation) Zaxpy(n int, alpha complex128, x []complex128, incX int, y
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1129,8 +1124,13 @@ func (Implementation) Zaxpy(n int, alpha complex128, x []complex128, incX int, y
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zaxpy(C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY))
 }
@@ -1144,19 +1144,14 @@ func (Implementation) Srot(n int, x []float32, incX int, y []float32, incY int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1164,8 +1159,13 @@ func (Implementation) Srot(n int, x []float32, incX int, y []float32, incY int, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_srot(C.int(n), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY), C.float(c), C.float(s))
 }
@@ -1179,19 +1179,14 @@ func (Implementation) Drot(n int, x []float64, incX int, y []float64, incY int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1199,8 +1194,13 @@ func (Implementation) Drot(n int, x []float64, incX int, y []float64, incY int, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_drot(C.int(n), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY), C.double(c), C.double(s))
 }
@@ -1214,12 +1214,11 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1227,8 +1226,9 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_sscal(C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX))
 }
@@ -1242,12 +1242,11 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1255,8 +1254,9 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_dscal(C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX))
 }
@@ -1267,12 +1267,11 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1280,8 +1279,9 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_cscal(C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX))
 }
@@ -1294,12 +1294,11 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1307,8 +1306,9 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_zscal(C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX))
 }
@@ -1319,12 +1319,11 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1332,8 +1331,9 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_csscal(C.int(n), C.float(alpha), unsafe.Pointer(_x), C.int(incX))
 }
@@ -1346,12 +1346,11 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if incX < 0 {
 		return
@@ -1359,8 +1358,9 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
-	if n == 0 {
-		return
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_zdscal(C.int(n), C.double(alpha), unsafe.Pointer(_x), C.int(incX))
 }
@@ -1388,20 +1388,8 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -1420,6 +1408,18 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_sgemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX), C.float(beta), (*C.float)(_y), C.int(incY))
 }
@@ -1454,20 +1454,8 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -1487,6 +1475,18 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	C.cblas_sgbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.int(kL), C.int(kU), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX), C.float(beta), (*C.float)(_y), C.int(incY))
 }
 
@@ -1497,14 +1497,6 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float32, lda int, x []float32, incX int) {
 	// declared at cblas.h:181:6 void cblas_strmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1514,6 +1506,14 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1526,14 +1526,6 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1542,6 +1534,14 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_strmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX))
 }
@@ -1553,14 +1553,6 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float32, lda int, x []float32, incX int) {
 	// declared at cblas.h:185:6 void cblas_stbmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1570,6 +1562,14 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1585,14 +1585,6 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1601,6 +1593,14 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_stbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX))
 }
@@ -1612,14 +1612,6 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []float32, incX int) {
 	// declared at cblas.h:189:6 void cblas_stpmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1629,6 +1621,14 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1641,8 +1641,17 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -1651,15 +1660,6 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *float32
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_stpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.float)(_ap), (*C.float)(_x), C.int(incX))
 }
@@ -1677,14 +1677,6 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float32, lda int, x []float32, incX int) {
 	// declared at cblas.h:192:6 void cblas_strsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1694,6 +1686,14 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1706,14 +1706,6 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1722,6 +1714,14 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_strsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX))
 }
@@ -1740,14 +1740,6 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float32, lda int, x []float32, incX int) {
 	// declared at cblas.h:196:6 void cblas_stbsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1757,6 +1749,14 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1772,14 +1772,6 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1788,6 +1780,14 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_stbsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX))
 }
@@ -1805,14 +1805,6 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []float32, incX int) {
 	// declared at cblas.h:200:6 void cblas_stpsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -1822,6 +1814,14 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -1834,8 +1834,17 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -1844,15 +1853,6 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *float32
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_stpsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.float)(_ap), (*C.float)(_x), C.int(incX))
 }
@@ -1880,20 +1880,8 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -1912,6 +1900,18 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_dgemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX), C.double(beta), (*C.double)(_y), C.int(incY))
 }
@@ -1946,20 +1946,8 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -1979,6 +1967,18 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	C.cblas_dgbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.int(kL), C.int(kU), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX), C.double(beta), (*C.double)(_y), C.int(incY))
 }
 
@@ -1989,14 +1989,6 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int) {
 	// declared at cblas.h:214:6 void cblas_dtrmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2006,6 +1998,14 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2018,14 +2018,6 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2034,6 +2026,14 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_dtrmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX))
 }
@@ -2045,14 +2045,6 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int) {
 	// declared at cblas.h:218:6 void cblas_dtbmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2062,6 +2054,14 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2077,14 +2077,6 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2093,6 +2085,14 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_dtbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX))
 }
@@ -2104,14 +2104,6 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []float64, incX int) {
 	// declared at cblas.h:222:6 void cblas_dtpmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2121,6 +2113,14 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2133,8 +2133,17 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -2143,15 +2152,6 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *float64
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_dtpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.double)(_ap), (*C.double)(_x), C.int(incX))
 }
@@ -2169,14 +2169,6 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []float64, lda int, x []float64, incX int) {
 	// declared at cblas.h:225:6 void cblas_dtrsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2186,6 +2178,14 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2198,14 +2198,6 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2214,6 +2206,14 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_dtrsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX))
 }
@@ -2232,14 +2232,6 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []float64, lda int, x []float64, incX int) {
 	// declared at cblas.h:229:6 void cblas_dtbsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2249,6 +2241,14 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2264,14 +2264,6 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2280,6 +2272,14 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_dtbsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX))
 }
@@ -2297,14 +2297,6 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []float64, incX int) {
 	// declared at cblas.h:233:6 void cblas_dtpsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2314,6 +2306,14 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2326,8 +2326,17 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -2336,15 +2345,6 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *float64
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_dtpsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), (*C.double)(_ap), (*C.double)(_x), C.int(incX))
 }
@@ -2368,20 +2368,8 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -2400,6 +2388,18 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cgemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -2429,20 +2429,8 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -2462,20 +2450,24 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	C.cblas_cgbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.int(kL), C.int(kU), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
 
 func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex64, lda int, x []complex64, incX int) {
 	// declared at cblas.h:247:6 void cblas_ctrmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2485,6 +2477,14 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2497,14 +2497,6 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2513,6 +2505,14 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_ctrmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
@@ -2520,14 +2520,6 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex64, lda int, x []complex64, incX int) {
 	// declared at cblas.h:251:6 void cblas_ctbmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2537,6 +2529,14 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2552,14 +2552,6 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2569,20 +2561,20 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	C.cblas_ctbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
 
 func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []complex64, incX int) {
 	// declared at cblas.h:255:6 void cblas_ctpmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2592,6 +2584,14 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2604,8 +2604,17 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -2615,29 +2624,12 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
-	}
 	C.cblas_ctpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX))
 }
 
 func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex64, lda int, x []complex64, incX int) {
 	// declared at cblas.h:258:6 void cblas_ctrsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2647,6 +2639,14 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2658,14 +2658,6 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
@@ -2676,20 +2668,20 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	C.cblas_ctrsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
 
 func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex64, lda int, x []complex64, incX int) {
 	// declared at cblas.h:262:6 void cblas_ctbsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2699,6 +2691,14 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2714,14 +2714,6 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2731,20 +2723,20 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	C.cblas_ctbsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
 
 func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []complex64, incX int) {
 	// declared at cblas.h:266:6 void cblas_ctpsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2754,6 +2746,14 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2766,8 +2766,17 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -2776,15 +2785,6 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *complex64
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_ctpsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX))
 }
@@ -2813,20 +2813,8 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -2845,6 +2833,18 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zgemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -2880,20 +2880,8 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -2913,6 +2901,18 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	C.cblas_zgbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.int(m), C.int(n), C.int(kL), C.int(kU), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
 
@@ -2924,14 +2924,6 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:280:6 void cblas_ztrmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2941,6 +2933,14 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -2953,14 +2953,6 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2969,6 +2961,14 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_ztrmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
@@ -2982,14 +2982,6 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:284:6 void cblas_ztbmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -2999,6 +2991,14 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3014,14 +3014,6 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3030,6 +3022,14 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_ztbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
@@ -3043,14 +3043,6 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []complex128, incX int) {
 	// declared at cblas.h:288:6 void cblas_ztpmv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -3060,6 +3052,14 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3072,8 +3072,17 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -3082,15 +3091,6 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *complex128
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_ztpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX))
 }
@@ -3109,14 +3109,6 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:291:6 void cblas_ztrsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -3126,6 +3118,14 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3138,14 +3138,6 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3154,6 +3146,14 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_ztrsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
@@ -3173,14 +3173,6 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k int, a []complex128, lda int, x []complex128, incX int) {
 	// declared at cblas.h:295:6 void cblas_ztbsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -3190,6 +3182,14 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3205,14 +3205,6 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3221,6 +3213,14 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
 	}
 	C.cblas_ztbsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), C.int(k), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX))
 }
@@ -3240,14 +3240,6 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int, ap, x []complex128, incX int) {
 	// declared at cblas.h:299:6 void cblas_ztpsv ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -3257,6 +3249,14 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 		tA = C.CblasConjTrans
 	default:
 		panic("blas: illegal transpose")
+	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
 	}
 	switch d {
 	case blas.NonUnit:
@@ -3269,8 +3269,17 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -3279,15 +3288,6 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	var _x *complex128
 	if len(x) > 0 {
 		_x = &x[0]
-	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_ztpsv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(n), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX))
 }
@@ -3310,20 +3310,8 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -3336,6 +3324,18 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_ssymv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX), C.float(beta), (*C.float)(_y), C.int(incY))
 }
@@ -3361,20 +3361,8 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -3387,6 +3375,18 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_ssbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.int(k), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_x), C.int(incX), C.float(beta), (*C.float)(_y), C.int(incY))
 }
@@ -3409,8 +3409,23 @@ func (Implementation) Sspmv(ul blas.Uplo, n int, alpha float32, ap, x []float32,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if incY == 0 {
+		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
+	}
+	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+		panic("blas: y index out of range")
 	}
 	var _ap *float32
 	if len(ap) > 0 {
@@ -3420,24 +3435,9 @@ func (Implementation) Sspmv(ul blas.Uplo, n int, alpha float32, ap, x []float32,
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
 	var _y *float32
 	if len(y) > 0 {
 		_y = &y[0]
-	}
-	if incY == 0 {
-		panic("blas: zero y index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
-		panic("blas: y index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_sspmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_ap), (*C.float)(_x), C.int(incX), C.float(beta), (*C.float)(_y), C.int(incY))
 }
@@ -3454,23 +3454,11 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3480,6 +3468,18 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_sger(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY), (*C.float)(_a), C.int(lda))
 }
@@ -3501,22 +3501,22 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_ssyr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_a), C.int(lda))
 }
@@ -3539,12 +3539,11 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -3552,12 +3551,13 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	var _ap *float32
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_sspr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_ap))
 }
@@ -3579,23 +3579,11 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3605,6 +3593,18 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_ssyr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY), (*C.float)(_a), C.int(lda))
 }
@@ -3627,19 +3627,14 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -3650,12 +3645,17 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	var _ap *float32
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_sspr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), (*C.float)(_x), C.int(incX), (*C.float)(_y), C.int(incY), (*C.float)(_ap))
 }
@@ -3678,20 +3678,8 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -3704,6 +3692,18 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_dsymv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX), C.double(beta), (*C.double)(_y), C.int(incY))
 }
@@ -3729,20 +3729,8 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -3755,6 +3743,18 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_dsbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.int(k), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_x), C.int(incX), C.double(beta), (*C.double)(_y), C.int(incY))
 }
@@ -3777,8 +3777,23 @@ func (Implementation) Dspmv(ul blas.Uplo, n int, alpha float64, ap, x []float64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if incY == 0 {
+		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
+	}
+	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+		panic("blas: y index out of range")
 	}
 	var _ap *float64
 	if len(ap) > 0 {
@@ -3788,24 +3803,9 @@ func (Implementation) Dspmv(ul blas.Uplo, n int, alpha float64, ap, x []float64,
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
 	var _y *float64
 	if len(y) > 0 {
 		_y = &y[0]
-	}
-	if incY == 0 {
-		panic("blas: zero y index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
-		panic("blas: y index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_dspmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_ap), (*C.double)(_x), C.int(incX), C.double(beta), (*C.double)(_y), C.int(incY))
 }
@@ -3822,23 +3822,11 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3848,6 +3836,18 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_dger(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY), (*C.double)(_a), C.int(lda))
 }
@@ -3869,22 +3869,22 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_dsyr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_a), C.int(lda))
 }
@@ -3907,12 +3907,11 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -3920,12 +3919,13 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	var _ap *float64
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_dspr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_ap))
 }
@@ -3947,23 +3947,11 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3973,6 +3961,18 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_dsyr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY), (*C.double)(_a), C.int(lda))
 }
@@ -3995,19 +3995,14 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -4018,12 +4013,17 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	var _ap *float64
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_dspr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), (*C.double)(_x), C.int(incX), (*C.double)(_y), C.int(incY), (*C.double)(_ap))
 }
@@ -4042,20 +4042,8 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -4068,6 +4056,18 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_chemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4089,20 +4089,8 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -4115,6 +4103,18 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_chbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4133,8 +4133,23 @@ func (Implementation) Chpmv(ul blas.Uplo, n int, alpha complex64, ap, x []comple
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if incY == 0 {
+		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
+	}
+	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+		panic("blas: y index out of range")
 	}
 	var _ap *complex64
 	if len(ap) > 0 {
@@ -4144,24 +4159,9 @@ func (Implementation) Chpmv(ul blas.Uplo, n int, alpha complex64, ap, x []comple
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
 	var _y *complex64
 	if len(y) > 0 {
 		_y = &y[0]
-	}
-	if incY == 0 {
-		panic("blas: zero y index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
-		panic("blas: y index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_chpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4175,23 +4175,11 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4201,6 +4189,18 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_cgeru(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4214,23 +4214,11 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4240,6 +4228,18 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_cgerc(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4258,22 +4258,22 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_cher(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4292,12 +4292,11 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -4305,12 +4304,13 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	var _ap *complex64
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_chpr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.float(alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_ap))
 }
@@ -4329,23 +4329,11 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4355,6 +4343,18 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_cher2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4373,19 +4373,14 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -4396,12 +4391,17 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	var _ap *complex64
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_chpr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_ap))
 }
@@ -4425,20 +4425,8 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -4451,6 +4439,18 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zhemv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4477,20 +4477,8 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
@@ -4503,6 +4491,18 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	}
 	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
 		panic("blas: index of a out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zhbmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4526,8 +4526,23 @@ func (Implementation) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap, x []compl
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if incX == 0 {
+		panic("blas: zero x index increment")
+	}
+	if incY == 0 {
+		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
+	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
+	}
+	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+		panic("blas: x index out of range")
+	}
+	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+		panic("blas: y index out of range")
 	}
 	var _ap *complex128
 	if len(ap) > 0 {
@@ -4537,24 +4552,9 @@ func (Implementation) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap, x []compl
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-	if incX == 0 {
-		panic("blas: zero x index increment")
-	}
 	var _y *complex128
 	if len(y) > 0 {
 		_y = &y[0]
-	}
-	if incY == 0 {
-		panic("blas: zero y index increment")
-	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
-		panic("blas: x index out of range")
-	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
-		panic("blas: y index out of range")
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_zhpmv(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_ap), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(&beta), unsafe.Pointer(_y), C.int(incY))
 }
@@ -4572,23 +4572,11 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4598,6 +4586,18 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_zgeru(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4615,23 +4615,11 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4641,6 +4629,18 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	}
 	if lda*(m-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_zgerc(C.enum_CBLAS_ORDER(rowMajor), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4664,22 +4664,22 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_zher(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4703,12 +4703,11 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -4716,12 +4715,13 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
 	var _ap *complex128
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_zhpr(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), C.double(alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_ap))
 }
@@ -4745,23 +4745,11 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4771,6 +4759,18 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	}
 	if lda*(n-1)+n > len(a) || lda < max(1, n) {
 		panic("blas: index of a out of range")
+	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
 	}
 	C.cblas_zher2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_a), C.int(lda))
 }
@@ -4794,19 +4794,14 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if n*(n+1)/2 > len(ap) {
 		panic("blas: index of ap out of range")
@@ -4817,12 +4812,17 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
+	}
 	var _ap *complex128
 	if len(ap) > 0 {
 		_ap = &ap[0]
-	}
-	if n == 0 {
-		return
 	}
 	C.cblas_zhpr2(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(_ap))
 }
@@ -4867,18 +4867,6 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float32
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *float32
-	if len(c) > 0 {
-		_c = &c[0]
-	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
 		rowA, colA = m, k
@@ -4899,39 +4887,6 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
-	C.cblas_sgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb), C.float(beta), (*C.float)(_c), C.int(ldc))
-}
-
-// Ssymm performs one of the matrix-matrix operations
-//  C = alpha * A * B + beta * C  if side == blas.Left
-//  C = alpha * B * A + beta * C  if side == blas.Right
-// where A is an n×n or m×m symmetric matrix, B and C are m×n matrices, and alpha
-// is a scalar.
-func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int) {
-	// declared at cblas.h:445:6 void cblas_ssymm ...
-
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
-	if m < 0 {
-		panic("blas: m < 0")
-	}
-	if n < 0 {
-		panic("blas: n < 0")
-	}
 	var _a *float32
 	if len(a) > 0 {
 		_a = &a[0]
@@ -4943,6 +4898,39 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	var _c *float32
 	if len(c) > 0 {
 		_c = &c[0]
+	}
+	C.cblas_sgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb), C.float(beta), (*C.float)(_c), C.int(ldc))
+}
+
+// Ssymm performs one of the matrix-matrix operations
+//  C = alpha * A * B + beta * C  if side == blas.Left
+//  C = alpha * B * A + beta * C  if side == blas.Right
+// where A is an n×n or m×m symmetric matrix, B and C are m×n matrices, and alpha
+// is a scalar.
+func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int) {
+	// declared at cblas.h:445:6 void cblas_ssymm ...
+
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
+	if m < 0 {
+		panic("blas: m < 0")
+	}
+	if n < 0 {
+		panic("blas: n < 0")
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -4959,6 +4947,18 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float32
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *float32
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_ssymm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb), C.float(beta), (*C.float)(_c), C.int(ldc))
 }
 
@@ -4970,14 +4970,6 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float32, a []float32, lda int, beta float32, c []float32, ldc int) {
 	// declared at cblas.h:450:6 void cblas_ssyrk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -4988,19 +4980,19 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *float32
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5014,6 +5006,14 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *float32
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_ssyrk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.float(alpha), (*C.float)(_a), C.int(lda), C.float(beta), (*C.float)(_c), C.int(ldc))
 }
 
@@ -5025,14 +5025,6 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha float32, a []float32, lda int, b []float32, ldb int, beta float32, c []float32, ldc int) {
 	// declared at cblas.h:454:6 void cblas_ssyr2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -5043,23 +5035,19 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float32
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *float32
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5076,6 +5064,18 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float32
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *float32
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_ssyr2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb), C.float(beta), (*C.float)(_c), C.int(ldc))
 }
 
@@ -5088,22 +5088,6 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int) {
 	// declared at cblas.h:459:6 void cblas_strmm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5114,6 +5098,14 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5122,19 +5114,19 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float32
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5147,6 +5139,14 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float32
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_strmm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb))
 }
@@ -5166,22 +5166,6 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float32, a []float32, lda int, b []float32, ldb int) {
 	// declared at cblas.h:464:6 void cblas_strsm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5192,6 +5176,14 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5200,19 +5192,19 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *float32
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float32
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5225,6 +5217,14 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *float32
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float32
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_strsm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), C.float(alpha), (*C.float)(_a), C.int(lda), (*C.float)(_b), C.int(ldb))
 }
@@ -5269,18 +5269,6 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *float64
-	if len(c) > 0 {
-		_c = &c[0]
-	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
 		rowA, colA = m, k
@@ -5301,39 +5289,6 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
-	C.cblas_dgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb), C.double(beta), (*C.double)(_c), C.int(ldc))
-}
-
-// Dsymm performs one of the matrix-matrix operations
-//  C = alpha * A * B + beta * C  if side == blas.Left
-//  C = alpha * B * A + beta * C  if side == blas.Right
-// where A is an n×n or m×m symmetric matrix, B and C are m×n matrices, and alpha
-// is a scalar.
-func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
-	// declared at cblas.h:475:6 void cblas_dsymm ...
-
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
-	if m < 0 {
-		panic("blas: m < 0")
-	}
-	if n < 0 {
-		panic("blas: n < 0")
-	}
 	var _a *float64
 	if len(a) > 0 {
 		_a = &a[0]
@@ -5345,6 +5300,39 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	var _c *float64
 	if len(c) > 0 {
 		_c = &c[0]
+	}
+	C.cblas_dgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb), C.double(beta), (*C.double)(_c), C.int(ldc))
+}
+
+// Dsymm performs one of the matrix-matrix operations
+//  C = alpha * A * B + beta * C  if side == blas.Left
+//  C = alpha * B * A + beta * C  if side == blas.Right
+// where A is an n×n or m×m symmetric matrix, B and C are m×n matrices, and alpha
+// is a scalar.
+func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
+	// declared at cblas.h:475:6 void cblas_dsymm ...
+
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
+	if m < 0 {
+		panic("blas: m < 0")
+	}
+	if n < 0 {
+		panic("blas: n < 0")
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5361,6 +5349,18 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *float64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_dsymm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb), C.double(beta), (*C.double)(_c), C.int(ldc))
 }
 
@@ -5372,14 +5372,6 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []float64, lda int, beta float64, c []float64, ldc int) {
 	// declared at cblas.h:480:6 void cblas_dsyrk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -5390,19 +5382,19 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *float64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5416,6 +5408,14 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *float64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_dsyrk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.double(alpha), (*C.double)(_a), C.int(lda), C.double(beta), (*C.double)(_c), C.int(ldc))
 }
 
@@ -5427,14 +5427,6 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []float64, lda int, b []float64, ldb int, beta float64, c []float64, ldc int) {
 	// declared at cblas.h:484:6 void cblas_dsyr2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -5445,23 +5437,19 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *float64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5478,6 +5466,18 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *float64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_dsyr2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb), C.double(beta), (*C.double)(_c), C.int(ldc))
 }
 
@@ -5490,22 +5490,6 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int) {
 	// declared at cblas.h:489:6 void cblas_dtrmm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5516,6 +5500,14 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5524,19 +5516,19 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float64
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5549,6 +5541,14 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float64
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_dtrmm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb))
 }
@@ -5568,22 +5568,6 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha float64, a []float64, lda int, b []float64, ldb int) {
 	// declared at cblas.h:494:6 void cblas_dtrsm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5594,6 +5578,14 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5602,19 +5594,19 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *float64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *float64
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5627,6 +5619,14 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *float64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *float64
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_dtrsm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), C.double(alpha), (*C.double)(_a), C.int(lda), (*C.double)(_b), C.int(ldb))
 }
@@ -5663,18 +5663,6 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
-	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
 		rowA, colA = m, k
@@ -5695,34 +5683,6 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
-	C.cblas_cgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
-}
-
-func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int) {
-	// declared at cblas.h:505:6 void cblas_csymm ...
-
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
-	if m < 0 {
-		panic("blas: m < 0")
-	}
-	if n < 0 {
-		panic("blas: n < 0")
-	}
 	var _a *complex64
 	if len(a) > 0 {
 		_a = &a[0]
@@ -5734,6 +5694,34 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	var _c *complex64
 	if len(c) > 0 {
 		_c = &c[0]
+	}
+	C.cblas_cgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
+}
+
+func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int) {
+	// declared at cblas.h:505:6 void cblas_csymm ...
+
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
+	if m < 0 {
+		panic("blas: m < 0")
+	}
+	if n < 0 {
+		panic("blas: n < 0")
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5750,20 +5738,24 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_csymm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex64, a []complex64, lda int, beta complex64, c []complex64, ldc int) {
 	// declared at cblas.h:510:6 void cblas_csyrk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -5772,19 +5764,19 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5798,20 +5790,20 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_csyrk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int) {
 	// declared at cblas.h:514:6 void cblas_csyr2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -5820,23 +5812,19 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -5853,28 +5841,24 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_csyr2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int) {
 	// declared at cblas.h:519:6 void cblas_ctrmm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5885,6 +5869,14 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5893,19 +5885,19 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5918,6 +5910,14 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_ctrmm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb))
 }
@@ -5925,22 +5925,6 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int) {
 	// declared at cblas.h:524:6 void cblas_ctrsm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -5951,6 +5935,14 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -5959,19 +5951,19 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -5984,6 +5976,14 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_ctrsm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb))
 }
@@ -6020,18 +6020,6 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	if k < 0 {
 		panic("blas: k < 0")
 	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
-	}
 	var rowA, colA, rowB, colB int
 	if tA == C.CblasNoTrans {
 		rowA, colA = m, k
@@ -6052,34 +6040,6 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
-	C.cblas_zgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
-}
-
-func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
-	// declared at cblas.h:535:6 void cblas_zsymm ...
-
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
-	if m < 0 {
-		panic("blas: m < 0")
-	}
-	if n < 0 {
-		panic("blas: n < 0")
-	}
 	var _a *complex128
 	if len(a) > 0 {
 		_a = &a[0]
@@ -6091,6 +6051,34 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	var _c *complex128
 	if len(c) > 0 {
 		_c = &c[0]
+	}
+	C.cblas_zgemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_TRANSPOSE(tB), C.int(m), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
+}
+
+func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
+	// declared at cblas.h:535:6 void cblas_zsymm ...
+
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
+	if m < 0 {
+		panic("blas: m < 0")
+	}
+	if n < 0 {
+		panic("blas: n < 0")
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6106,6 +6094,18 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	}
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
 	}
 	C.cblas_zsymm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
@@ -6113,14 +6113,6 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, beta complex128, c []complex128, ldc int) {
 	// declared at cblas.h:540:6 void cblas_zsyrk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6129,19 +6121,19 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6154,6 +6146,14 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	}
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
 	}
 	C.cblas_zsyrk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
@@ -6161,14 +6161,6 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
 	// declared at cblas.h:544:6 void cblas_zsyr2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6177,23 +6169,19 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6209,6 +6197,18 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
 	}
 	C.cblas_zsyr2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
@@ -6216,22 +6216,6 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int) {
 	// declared at cblas.h:549:6 void cblas_ztrmm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -6242,6 +6226,14 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -6250,19 +6242,19 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6275,6 +6267,14 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_ztrmm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb))
 }
@@ -6282,22 +6282,6 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas.Diag, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int) {
 	// declared at cblas.h:554:6 void cblas_ztrsm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch tA {
 	case blas.NoTrans:
 		tA = C.CblasNoTrans
@@ -6308,6 +6292,14 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	switch d {
 	case blas.NonUnit:
 		d = C.CblasNonUnit
@@ -6316,19 +6308,19 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	default:
 		panic("blas: illegal diagonal")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6341,6 +6333,14 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	}
 	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
 		panic("blas: index of b out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
 	}
 	C.cblas_ztrsm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(tA), C.enum_CBLAS_DIAG(d), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb))
 }
@@ -6348,14 +6348,6 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta complex64, c []complex64, ldc int) {
 	// declared at cblas.h:564:6 void cblas_chemm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
 	switch ul {
 	case blas.Upper:
 		ul = C.CblasUpper
@@ -6364,23 +6356,19 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	default:
 		panic("blas: illegal triangle")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6396,6 +6384,18 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	}
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
+	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
 	}
 	C.cblas_chemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
@@ -6403,14 +6403,6 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float32, a []complex64, lda int, beta float32, c []complex64, ldc int) {
 	// declared at cblas.h:569:6 void cblas_cherk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6419,19 +6411,19 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6445,20 +6437,20 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_cherk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.float(alpha), unsafe.Pointer(_a), C.int(lda), C.float(beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex64, a []complex64, lda int, b []complex64, ldb int, beta float32, c []complex64, ldc int) {
 	// declared at cblas.h:573:6 void cblas_cher2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6467,23 +6459,19 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex64
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex64
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex64
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6500,20 +6488,24 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex64
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex64
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex64
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_cher2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), C.float(beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta complex128, c []complex128, ldc int) {
 	// declared at cblas.h:578:6 void cblas_zhemm ...
 
-	switch s {
-	case blas.Left:
-		s = C.CblasLeft
-	case blas.Right:
-		s = C.CblasRight
-	default:
-		panic("blas: illegal side")
-	}
 	switch ul {
 	case blas.Upper:
 		ul = C.CblasUpper
@@ -6522,23 +6514,19 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	default:
 		panic("blas: illegal triangle")
 	}
+	switch s {
+	case blas.Left:
+		s = C.CblasLeft
+	case blas.Right:
+		s = C.CblasRight
+	default:
+		panic("blas: illegal side")
+	}
 	if m < 0 {
 		panic("blas: m < 0")
 	}
 	if n < 0 {
 		panic("blas: n < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var k int
 	if s == C.CblasLeft {
@@ -6555,20 +6543,24 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_zhemm(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_SIDE(s), C.enum_CBLAS_UPLO(ul), C.int(m), C.int(n), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), unsafe.Pointer(&beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha float64, a []complex128, lda int, beta float64, c []complex128, ldc int) {
 	// declared at cblas.h:583:6 void cblas_zherk ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6577,19 +6569,19 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6603,20 +6595,20 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
 	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
+	}
 	C.cblas_zherk(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), C.double(alpha), unsafe.Pointer(_a), C.int(lda), C.double(beta), unsafe.Pointer(_c), C.int(ldc))
 }
 
 func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha complex128, a []complex128, lda int, b []complex128, ldb int, beta float64, c []complex128, ldc int) {
 	// declared at cblas.h:587:6 void cblas_zher2k ...
 
-	switch ul {
-	case blas.Upper:
-		ul = C.CblasUpper
-	case blas.Lower:
-		ul = C.CblasLower
-	default:
-		panic("blas: illegal triangle")
-	}
 	switch t {
 	case blas.NoTrans:
 		t = C.CblasNoTrans
@@ -6625,23 +6617,19 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	default:
 		panic("blas: illegal transpose")
 	}
+	switch ul {
+	case blas.Upper:
+		ul = C.CblasUpper
+	case blas.Lower:
+		ul = C.CblasLower
+	default:
+		panic("blas: illegal triangle")
+	}
 	if n < 0 {
 		panic("blas: n < 0")
 	}
 	if k < 0 {
 		panic("blas: k < 0")
-	}
-	var _a *complex128
-	if len(a) > 0 {
-		_a = &a[0]
-	}
-	var _b *complex128
-	if len(b) > 0 {
-		_b = &b[0]
-	}
-	var _c *complex128
-	if len(c) > 0 {
-		_c = &c[0]
 	}
 	var row, col int
 	if t == C.CblasNoTrans {
@@ -6657,6 +6645,18 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
 		panic("blas: index of c out of range")
+	}
+	var _a *complex128
+	if len(a) > 0 {
+		_a = &a[0]
+	}
+	var _b *complex128
+	if len(b) > 0 {
+		_b = &b[0]
+	}
+	var _c *complex128
+	if len(c) > 0 {
+		_c = &c[0]
 	}
 	C.cblas_zher2k(C.enum_CBLAS_ORDER(rowMajor), C.enum_CBLAS_UPLO(ul), C.enum_CBLAS_TRANSPOSE(t), C.int(n), C.int(k), unsafe.Pointer(&alpha), unsafe.Pointer(_a), C.int(lda), unsafe.Pointer(_b), C.int(ldb), C.double(beta), unsafe.Pointer(_c), C.int(ldc))
 }

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -73,19 +73,17 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
+		panic("blas: illegal blas.Flag value")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -93,11 +91,13 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+	var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
-	if n == 0 {
-		return
+	var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	pi := srotmParams{
 		flag: float32(p.Flag),
@@ -118,19 +118,17 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
+		panic("blas: illegal blas.Flag value")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -138,11 +136,13 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+	var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
-	if n == 0 {
-		return
+	var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	pi := drotmParams{
 		flag: float64(p.Flag),
@@ -154,19 +154,14 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -174,8 +169,13 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cdotu_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotu))
 	return dotu
@@ -184,19 +184,14 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -204,8 +199,13 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cdotc_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotc))
 	return dotc
@@ -214,19 +214,14 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -234,8 +229,13 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zdotu_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotu))
 	return dotu
@@ -244,19 +244,14 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-	var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -264,8 +259,13 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+	var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+	var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zdotc_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotc))
 	return dotc

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -1353,7 +1353,10 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if incX < 0 {
+		return
+	}
+	if incX > 0 && (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	if n == 0 {

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -421,13 +421,10 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -449,13 +446,10 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -477,13 +471,10 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -505,13 +496,10 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -530,13 +518,10 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -555,13 +540,10 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -583,13 +565,10 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -611,13 +590,10 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return 0
 	}
-	if incX < 0 {
-		return 0
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -639,13 +615,10 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
-		return -1
-	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -667,13 +640,10 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
-		return -1
-	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -692,13 +662,10 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
-		return -1
-	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -719,13 +686,10 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
-		return -1
-	}
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -1217,13 +1181,10 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -1245,13 +1206,10 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -1270,13 +1228,10 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -1297,13 +1252,10 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -1322,13 +1274,10 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -1349,13 +1298,10 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-	if n == 0 {
+	if n == 0 || incX < 0 {
 		return
 	}
-	if incX < 0 {
-		return
-	}
-	if incX > 0 && (n-1)*incX >= len(x) {
+	if (n-1)*incX >= len(x) {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -1396,6 +1342,9 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1465,6 +1414,9 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -1538,6 +1490,9 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -1599,6 +1554,9 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1724,6 +1682,9 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -1792,6 +1753,9 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1907,6 +1871,9 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -1975,6 +1942,9 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2048,6 +2018,9 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -2109,6 +2082,9 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -2234,6 +2210,9 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -2302,6 +2281,9 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -2413,6 +2395,9 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2476,6 +2461,9 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -2545,6 +2533,9 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -2602,6 +2593,9 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -2713,6 +2707,9 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -2770,6 +2767,9 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -2876,6 +2876,9 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
 		lenX, lenY = n, m
@@ -2945,6 +2948,9 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	var lenX, lenY int
 	if tA == C.CblasNoTrans {
@@ -3019,6 +3025,9 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3082,6 +3091,9 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3210,6 +3222,9 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3279,6 +3294,9 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3391,6 +3409,9 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3444,6 +3465,9 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3541,6 +3565,9 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3587,6 +3614,9 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3671,6 +3701,9 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3774,6 +3807,9 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3827,6 +3863,9 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -3924,6 +3963,9 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -3970,6 +4012,9 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4054,6 +4099,9 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4153,6 +4201,9 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -4202,6 +4253,9 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4292,6 +4346,9 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -4333,6 +4390,9 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4377,6 +4437,9 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4454,6 +4517,9 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4554,6 +4620,9 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if n == 0 {
+		return
+	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -4608,6 +4677,9 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4707,6 +4779,9 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if incY == 0 {
 		panic("blas: zero y index increment")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
@@ -4752,6 +4827,9 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4801,6 +4879,9 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -4888,6 +4969,9 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -5025,6 +5109,9 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5094,6 +5181,9 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5162,6 +5252,9 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5225,6 +5318,9 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
@@ -5311,6 +5407,9 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5395,6 +5494,9 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5472,6 +5574,9 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5541,6 +5646,9 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5609,6 +5717,9 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5672,6 +5783,9 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
@@ -5758,6 +5872,9 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5842,6 +5959,9 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5911,6 +6031,9 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -5975,6 +6098,9 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6036,6 +6162,9 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6092,6 +6221,9 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
@@ -6172,6 +6304,9 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6244,6 +6379,9 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6313,6 +6451,9 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6377,6 +6518,9 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6438,6 +6582,9 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6494,6 +6641,9 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
@@ -6574,6 +6724,9 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6646,6 +6799,9 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if ldb < max(1, n) {
 		panic("blas: bad ldb")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6702,6 +6858,9 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if m == 0 || n == 0 {
+		return
 	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
@@ -6764,6 +6923,9 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6820,6 +6982,9 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
@@ -6885,6 +7050,9 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if m == 0 || n == 0 {
+		return
+	}
 	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -6946,6 +7114,9 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
 	}
+	if n == 0 {
+		return
+	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
@@ -7002,6 +7173,9 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	}
 	if ldc < max(1, n) {
 		panic("blas: bad ldc")
+	}
+	if n == 0 {
+		return
 	}
 	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -85,10 +85,10 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -130,10 +130,10 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -163,10 +163,10 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex64
@@ -193,10 +193,10 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex64
@@ -223,10 +223,10 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex128
@@ -253,10 +253,10 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex128
@@ -290,10 +290,10 @@ func (Implementation) Sdsdot(n int, alpha float32, x []float32, incX int, y []fl
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -324,10 +324,10 @@ func (Implementation) Dsdot(n int, x []float32, incX int, y []float32, incY int)
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -358,10 +358,10 @@ func (Implementation) Sdot(n int, x []float32, incX int, y []float32, incY int) 
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -392,10 +392,10 @@ func (Implementation) Ddot(n int, x []float64, incX int, y []float64, incY int) 
 	if n == 0 {
 		return 0
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -424,7 +424,7 @@ func (Implementation) Snrm2(n int, x []float32, incX int) float32 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -449,7 +449,7 @@ func (Implementation) Sasum(n int, x []float32, incX int) float32 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -474,7 +474,7 @@ func (Implementation) Dnrm2(n int, x []float64, incX int) float64 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -499,7 +499,7 @@ func (Implementation) Dasum(n int, x []float64, incX int) float64 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -521,7 +521,7 @@ func (Implementation) Scnrm2(n int, x []complex64, incX int) float32 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -543,7 +543,7 @@ func (Implementation) Scasum(n int, x []complex64, incX int) float32 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -568,7 +568,7 @@ func (Implementation) Dznrm2(n int, x []complex128, incX int) float64 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -593,7 +593,7 @@ func (Implementation) Dzasum(n int, x []complex128, incX int) float64 {
 	if n == 0 || incX < 0 {
 		return 0
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -618,7 +618,7 @@ func (Implementation) Isamax(n int, x []float32, incX int) int {
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -643,7 +643,7 @@ func (Implementation) Idamax(n int, x []float64, incX int) int {
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -665,7 +665,7 @@ func (Implementation) Icamax(n int, x []complex64, incX int) int {
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -689,7 +689,7 @@ func (Implementation) Izamax(n int, x []complex128, incX int) int {
 	if n == 0 || incX < 0 {
 		return -1
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -716,10 +716,10 @@ func (Implementation) Sswap(n int, x []float32, incX int, y []float32, incY int)
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -750,10 +750,10 @@ func (Implementation) Scopy(n int, x []float32, incX int, y []float32, incY int)
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -784,10 +784,10 @@ func (Implementation) Saxpy(n int, alpha float32, x []float32, incX int, y []flo
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -818,10 +818,10 @@ func (Implementation) Dswap(n int, x []float64, incX int, y []float64, incY int)
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -852,10 +852,10 @@ func (Implementation) Dcopy(n int, x []float64, incX int, y []float64, incY int)
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -886,10 +886,10 @@ func (Implementation) Daxpy(n int, alpha float64, x []float64, incX int, y []flo
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -918,10 +918,10 @@ func (Implementation) Cswap(n int, x []complex64, incX int, y []complex64, incY 
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex64
@@ -950,10 +950,10 @@ func (Implementation) Ccopy(n int, x []complex64, incX int, y []complex64, incY 
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex64
@@ -982,10 +982,10 @@ func (Implementation) Caxpy(n int, alpha complex64, x []complex64, incX int, y [
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex64
@@ -1015,10 +1015,10 @@ func (Implementation) Zswap(n int, x []complex128, incX int, y []complex128, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex128
@@ -1048,10 +1048,10 @@ func (Implementation) Zcopy(n int, x []complex128, incX int, y []complex128, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex128
@@ -1082,10 +1082,10 @@ func (Implementation) Zaxpy(n int, alpha complex128, x []complex128, incX int, y
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *complex128
@@ -1117,10 +1117,10 @@ func (Implementation) Srot(n int, x []float32, incX int, y []float32, incY int, 
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float32
@@ -1152,10 +1152,10 @@ func (Implementation) Drot(n int, x []float64, incX int, y []float64, incY int, 
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _x *float64
@@ -1184,7 +1184,7 @@ func (Implementation) Sscal(n int, alpha float32, x []float32, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float32
@@ -1209,7 +1209,7 @@ func (Implementation) Dscal(n int, alpha float64, x []float64, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *float64
@@ -1231,7 +1231,7 @@ func (Implementation) Cscal(n int, alpha complex64, x []complex64, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -1255,7 +1255,7 @@ func (Implementation) Zscal(n int, alpha complex128, x []complex128, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -1277,7 +1277,7 @@ func (Implementation) Csscal(n int, alpha float32, x []complex64, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex64
@@ -1301,7 +1301,7 @@ func (Implementation) Zdscal(n int, alpha float64, x []complex128, incX int) {
 	if n == 0 || incX < 0 {
 		return
 	}
-	if (n-1)*incX >= len(x) {
+	if len(x) <= (n-1)*incX {
 		panic("blas: x index out of range")
 	}
 	var _x *complex128
@@ -1346,7 +1346,7 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -1355,10 +1355,10 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float32
@@ -1418,7 +1418,7 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -1427,10 +1427,10 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float32
@@ -1493,10 +1493,10 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float32
@@ -1558,10 +1558,10 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float32
@@ -1617,10 +1617,10 @@ func (Implementation) Stpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *float32
@@ -1685,10 +1685,10 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float32
@@ -1757,10 +1757,10 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float32
@@ -1822,10 +1822,10 @@ func (Implementation) Stpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *float32
@@ -1874,7 +1874,7 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -1883,10 +1883,10 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float64
@@ -1946,7 +1946,7 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -1955,10 +1955,10 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float64
@@ -2021,10 +2021,10 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float64
@@ -2086,10 +2086,10 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float64
@@ -2145,10 +2145,10 @@ func (Implementation) Dtpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *float64
@@ -2213,10 +2213,10 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float64
@@ -2285,10 +2285,10 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *float64
@@ -2350,10 +2350,10 @@ func (Implementation) Dtpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *float64
@@ -2398,7 +2398,7 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -2407,10 +2407,10 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex64
@@ -2465,7 +2465,7 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -2474,10 +2474,10 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex64
@@ -2536,10 +2536,10 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex64
@@ -2597,10 +2597,10 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex64
@@ -2652,10 +2652,10 @@ func (Implementation) Ctpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *complex64
@@ -2710,10 +2710,10 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex64
@@ -2771,10 +2771,10 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex64
@@ -2826,10 +2826,10 @@ func (Implementation) Ctpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *complex64
@@ -2879,7 +2879,7 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -2888,10 +2888,10 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex128
@@ -2952,7 +2952,7 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
+	if len(a) < lda*(min(m, n+kL)-1)+kL+kU+1 {
 		panic("blas: index of a out of range")
 	}
 	var lenX, lenY int
@@ -2961,10 +2961,10 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	} else {
 		lenX, lenY = m, n
 	}
-	if (incX > 0 && (lenX-1)*incX >= len(x)) || (incX < 0 && (1-lenX)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (lenX-1)*incX) || (incX < 0 && len(x) <= (1-lenX)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (lenY-1)*incY) || (incY < 0 && len(y) <= (1-lenY)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex128
@@ -3028,10 +3028,10 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex128
@@ -3095,10 +3095,10 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex128
@@ -3156,10 +3156,10 @@ func (Implementation) Ztpmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *complex128
@@ -3225,10 +3225,10 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex128
@@ -3298,10 +3298,10 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _a *complex128
@@ -3365,10 +3365,10 @@ func (Implementation) Ztpsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
 	var _ap *complex128
@@ -3412,13 +3412,13 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float32
@@ -3469,13 +3469,13 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float32
@@ -3520,13 +3520,13 @@ func (Implementation) Sspmv(ul blas.Uplo, n int, alpha float32, ap, x []float32,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _ap *float32
@@ -3568,13 +3568,13 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3618,10 +3618,10 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3659,10 +3659,10 @@ func (Implementation) Sspr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *float32
@@ -3705,13 +3705,13 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3756,13 +3756,13 @@ func (Implementation) Sspr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *float32
@@ -3810,13 +3810,13 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float64
@@ -3867,13 +3867,13 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *float64
@@ -3918,13 +3918,13 @@ func (Implementation) Dspmv(ul blas.Uplo, n int, alpha float64, ap, x []float64,
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _ap *float64
@@ -3966,13 +3966,13 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -4016,10 +4016,10 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -4057,10 +4057,10 @@ func (Implementation) Dspr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *float64
@@ -4103,13 +4103,13 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -4154,13 +4154,13 @@ func (Implementation) Dspr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *float64
@@ -4204,13 +4204,13 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex64
@@ -4257,13 +4257,13 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex64
@@ -4304,13 +4304,13 @@ func (Implementation) Chpmv(ul blas.Uplo, n int, alpha complex64, ap, x []comple
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _ap *complex64
@@ -4349,13 +4349,13 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4394,13 +4394,13 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4441,10 +4441,10 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4478,10 +4478,10 @@ func (Implementation) Chpr(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *complex64
@@ -4521,13 +4521,13 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4568,13 +4568,13 @@ func (Implementation) Chpr2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *complex64
@@ -4623,13 +4623,13 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex128
@@ -4681,13 +4681,13 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if n == 0 {
 		return
 	}
-	if lda*(n-1)+k+1 > len(a) {
+	if len(a) < lda*(n-1)+k+1 {
 		panic("blas: index of a out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _a *complex128
@@ -4733,13 +4733,13 @@ func (Implementation) Zhpmv(ul blas.Uplo, n int, alpha complex128, ap, x []compl
 	if n == 0 {
 		return
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
 	var _ap *complex128
@@ -4782,13 +4782,13 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4831,13 +4831,13 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	if m == 0 || n == 0 {
 		return
 	}
-	if (incX > 0 && (m-1)*incX >= len(x)) || (incX < 0 && (1-m)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (m-1)*incX) || (incX < 0 && len(x) <= (1-m)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) {
+	if len(a) < lda*(m-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4883,10 +4883,10 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4925,10 +4925,10 @@ func (Implementation) Zhpr(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *complex128
@@ -4973,13 +4973,13 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) {
+	if len(a) < lda*(n-1)+n {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -5025,13 +5025,13 @@ func (Implementation) Zhpr2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n == 0 {
 		return
 	}
-	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
+	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic("blas: x index out of range")
 	}
-	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
+	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic("blas: y index out of range")
 	}
-	if n*(n+1)/2 > len(ap) {
+	if len(ap) < n*(n+1)/2 {
 		panic("blas: index of ap out of range")
 	}
 	var _x *complex128
@@ -5112,13 +5112,13 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(rowA-1)+colA > len(a) {
+	if len(a) < lda*(rowA-1)+colA {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) {
+	if len(b) < ldb*(rowB-1)+colB {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5184,13 +5184,13 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5255,10 +5255,10 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5322,13 +5322,13 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5410,10 +5410,10 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *float32
@@ -5497,10 +5497,10 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *float32
@@ -5577,13 +5577,13 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(rowA-1)+colA > len(a) {
+	if len(a) < lda*(rowA-1)+colA {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) {
+	if len(b) < ldb*(rowB-1)+colB {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5649,13 +5649,13 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5720,10 +5720,10 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5787,13 +5787,13 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5875,10 +5875,10 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *float64
@@ -5962,10 +5962,10 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *float64
@@ -6034,13 +6034,13 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(rowA-1)+colA > len(a) {
+	if len(a) < lda*(rowA-1)+colA {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) {
+	if len(b) < ldb*(rowB-1)+colB {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6101,13 +6101,13 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6165,10 +6165,10 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6225,13 +6225,13 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6307,10 +6307,10 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex64
@@ -6382,10 +6382,10 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex64
@@ -6454,13 +6454,13 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(rowA-1)+colA > len(a) {
+	if len(a) < lda*(rowA-1)+colA {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) {
+	if len(b) < ldb*(rowB-1)+colB {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6521,13 +6521,13 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6585,10 +6585,10 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6645,13 +6645,13 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6727,10 +6727,10 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex128
@@ -6802,10 +6802,10 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex128
@@ -6862,13 +6862,13 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6926,10 +6926,10 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6986,13 +6986,13 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -7053,13 +7053,13 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	if m == 0 || n == 0 {
 		return
 	}
-	if lda*(k-1)+k > len(a) {
+	if len(a) < lda*(k-1)+k {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) {
+	if len(b) < ldb*(m-1)+n {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) {
+	if len(c) < ldc*(m-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -7117,10 +7117,10 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -7177,13 +7177,13 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	if n == 0 {
 		return
 	}
-	if lda*(row-1)+col > len(a) {
+	if len(a) < lda*(row-1)+col {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) {
+	if len(b) < ldb*(row-1)+col {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) {
+	if len(c) < ldc*(n-1)+n {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128

--- a/blas/netlib/blas.go
+++ b/blas/netlib/blas.go
@@ -1388,6 +1388,9 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1406,7 +1409,7 @@ func (Implementation) Sgemv(tA blas.Transpose, m, n int, alpha float32, a []floa
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1454,6 +1457,9 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
+	if lda < kL+kU+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1472,7 +1478,7 @@ func (Implementation) Sgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float32, 
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1526,13 +1532,16 @@ func (Implementation) Strmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1585,13 +1594,16 @@ func (Implementation) Stbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1706,13 +1718,16 @@ func (Implementation) Strsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1772,13 +1787,16 @@ func (Implementation) Stbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -1880,6 +1898,9 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1898,7 +1919,7 @@ func (Implementation) Dgemv(tA blas.Transpose, m, n int, alpha float64, a []floa
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -1946,6 +1967,9 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
+	if lda < kL+kU+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -1964,7 +1988,7 @@ func (Implementation) Dgbmv(tA blas.Transpose, m, n, kL, kU int, alpha float64, 
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -2018,13 +2042,16 @@ func (Implementation) Dtrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -2077,13 +2104,16 @@ func (Implementation) Dtbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -2198,13 +2228,16 @@ func (Implementation) Dtrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -2264,13 +2297,16 @@ func (Implementation) Dtbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -2368,6 +2404,9 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2386,7 +2425,7 @@ func (Implementation) Cgemv(tA blas.Transpose, m, n int, alpha complex64, a []co
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2429,6 +2468,9 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
+	if lda < kL+kU+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2447,7 +2489,7 @@ func (Implementation) Cgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex64
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2497,13 +2539,16 @@ func (Implementation) Ctrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2552,13 +2597,16 @@ func (Implementation) Ctbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2659,13 +2707,16 @@ func (Implementation) Ctrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2714,13 +2765,16 @@ func (Implementation) Ctbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -2813,6 +2867,9 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2831,7 +2888,7 @@ func (Implementation) Zgemv(tA blas.Transpose, m, n int, alpha complex128, a []c
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -2880,6 +2937,9 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if kU < 0 {
 		panic("blas: kU < 0")
 	}
+	if lda < kL+kU+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -2898,7 +2958,7 @@ func (Implementation) Zgbmv(tA blas.Transpose, m, n, kL, kU int, alpha complex12
 	if (incY > 0 && (lenY-1)*incY >= len(y)) || (incY < 0 && (1-lenY)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) || lda < kL+kU+1 {
+	if lda*(min(m, n+kL)-1)+kL+kU+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -2953,13 +3013,16 @@ func (Implementation) Ztrmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -3014,13 +3077,16 @@ func (Implementation) Ztbmv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -3138,13 +3204,16 @@ func (Implementation) Ztrsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -3205,13 +3274,16 @@ func (Implementation) Ztbsv(ul blas.Uplo, tA blas.Transpose, d blas.Diag, n, k i
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -3310,6 +3382,9 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3322,7 +3397,7 @@ func (Implementation) Ssymv(ul blas.Uplo, n int, alpha float32, a []float32, lda
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -3361,6 +3436,9 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3373,7 +3451,7 @@ func (Implementation) Ssbmv(ul blas.Uplo, n, k int, alpha float32, a []float32, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float32
@@ -3454,6 +3532,9 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3466,7 +3547,7 @@ func (Implementation) Sger(m, n int, alpha float32, x []float32, incX int, y []f
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3501,13 +3582,16 @@ func (Implementation) Ssyr(ul blas.Uplo, n int, alpha float32, x []float32, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3579,6 +3663,9 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3591,7 +3678,7 @@ func (Implementation) Ssyr2(ul blas.Uplo, n int, alpha float32, x []float32, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float32
@@ -3678,6 +3765,9 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3690,7 +3780,7 @@ func (Implementation) Dsymv(ul blas.Uplo, n int, alpha float64, a []float64, lda
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -3729,6 +3819,9 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3741,7 +3834,7 @@ func (Implementation) Dsbmv(ul blas.Uplo, n, k int, alpha float64, a []float64, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *float64
@@ -3822,6 +3915,9 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3834,7 +3930,7 @@ func (Implementation) Dger(m, n int, alpha float64, x []float64, incX int, y []f
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -3869,13 +3965,16 @@ func (Implementation) Dsyr(ul blas.Uplo, n int, alpha float64, x []float64, incX
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -3947,6 +4046,9 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -3959,7 +4061,7 @@ func (Implementation) Dsyr2(ul blas.Uplo, n int, alpha float64, x []float64, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *float64
@@ -4042,6 +4144,9 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4054,7 +4159,7 @@ func (Implementation) Chemv(ul blas.Uplo, n int, alpha complex64, a []complex64,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -4089,6 +4194,9 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4101,7 +4209,7 @@ func (Implementation) Chbmv(ul blas.Uplo, n, k int, alpha complex64, a []complex
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex64
@@ -4175,6 +4283,9 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4187,7 +4298,7 @@ func (Implementation) Cgeru(m, n int, alpha complex64, x []complex64, incX int, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4214,6 +4325,9 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4226,7 +4340,7 @@ func (Implementation) Cgerc(m, n int, alpha complex64, x []complex64, incX int, 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4258,13 +4372,16 @@ func (Implementation) Cher(ul blas.Uplo, n int, alpha float32, x []complex64, in
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4329,6 +4446,9 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4341,7 +4461,7 @@ func (Implementation) Cher2(ul blas.Uplo, n int, alpha complex64, x []complex64,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex64
@@ -4425,6 +4545,9 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4437,7 +4560,7 @@ func (Implementation) Zhemv(ul blas.Uplo, n int, alpha complex128, a []complex12
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -4477,6 +4600,9 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if k < 0 {
 		panic("blas: k < 0")
 	}
+	if lda < k+1 {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4489,7 +4615,7 @@ func (Implementation) Zhbmv(ul blas.Uplo, n, k int, alpha complex128, a []comple
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+k+1 > len(a) || lda < k+1 {
+	if lda*(n-1)+k+1 > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _a *complex128
@@ -4572,6 +4698,9 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4584,7 +4713,7 @@ func (Implementation) Zgeru(m, n int, alpha complex128, x []complex128, incX int
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4615,6 +4744,9 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4627,7 +4759,7 @@ func (Implementation) Zgerc(m, n int, alpha complex128, x []complex128, incX int
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(m-1)+n > len(a) || lda < max(1, n) {
+	if lda*(m-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4664,13 +4796,16 @@ func (Implementation) Zher(ul blas.Uplo, n int, alpha float64, x []complex128, i
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4745,6 +4880,9 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if n < 0 {
 		panic("blas: n < 0")
 	}
+	if lda < max(1, n) {
+		panic("blas: bad lda")
+	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
@@ -4757,7 +4895,7 @@ func (Implementation) Zher2(ul blas.Uplo, n int, alpha complex128, x []complex12
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if lda*(n-1)+n > len(a) || lda < max(1, n) {
+	if lda*(n-1)+n > len(a) {
 		panic("blas: index of a out of range")
 	}
 	var _x *complex128
@@ -4878,13 +5016,22 @@ func (Implementation) Sgemm(tA, tB blas.Transpose, m, n, k int, alpha float32, a
 	} else {
 		rowB, colB = n, k
 	}
-	if lda*(rowA-1)+colA > len(a) || lda < max(1, colA) {
+	if lda < max(1, colA) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, colB) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) || ldb < max(1, colB) {
+	if ldb*(rowB-1)+colB > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -4938,13 +5085,22 @@ func (Implementation) Ssymm(s blas.Side, ul blas.Uplo, m, n int, alpha float32, 
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5000,10 +5156,16 @@ func (Implementation) Ssyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5055,13 +5217,22 @@ func (Implementation) Ssyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float32
@@ -5134,10 +5305,16 @@ func (Implementation) Strmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *float32
@@ -5212,10 +5389,16 @@ func (Implementation) Strsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *float32
@@ -5280,13 +5463,22 @@ func (Implementation) Dgemm(tA, tB blas.Transpose, m, n, k int, alpha float64, a
 	} else {
 		rowB, colB = n, k
 	}
-	if lda*(rowA-1)+colA > len(a) || lda < max(1, colA) {
+	if lda < max(1, colA) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, colB) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) || ldb < max(1, colB) {
+	if ldb*(rowB-1)+colB > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5340,13 +5532,22 @@ func (Implementation) Dsymm(s blas.Side, ul blas.Uplo, m, n int, alpha float64, 
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5402,10 +5603,16 @@ func (Implementation) Dsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5457,13 +5664,22 @@ func (Implementation) Dsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha flo
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *float64
@@ -5536,10 +5752,16 @@ func (Implementation) Dtrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *float64
@@ -5614,10 +5836,16 @@ func (Implementation) Dtrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *float64
@@ -5674,13 +5902,22 @@ func (Implementation) Cgemm(tA, tB blas.Transpose, m, n, k int, alpha complex64,
 	} else {
 		rowB, colB = n, k
 	}
-	if lda*(rowA-1)+colA > len(a) || lda < max(1, colA) {
+	if lda < max(1, colA) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, colB) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) || ldb < max(1, colB) {
+	if ldb*(rowB-1)+colB > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -5729,13 +5966,22 @@ func (Implementation) Csymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -5784,10 +6030,16 @@ func (Implementation) Csyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -5832,13 +6084,22 @@ func (Implementation) Csyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -5905,10 +6166,16 @@ func (Implementation) Ctrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex64
@@ -5971,10 +6238,16 @@ func (Implementation) Ctrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex64
@@ -6031,13 +6304,22 @@ func (Implementation) Zgemm(tA, tB blas.Transpose, m, n, k int, alpha complex128
 	} else {
 		rowB, colB = n, k
 	}
-	if lda*(rowA-1)+colA > len(a) || lda < max(1, colA) {
+	if lda < max(1, colA) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, colB) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(rowA-1)+colA > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(rowB-1)+colB > len(b) || ldb < max(1, colB) {
+	if ldb*(rowB-1)+colB > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6086,13 +6368,22 @@ func (Implementation) Zsymm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6141,10 +6432,16 @@ func (Implementation) Zsyrk(ul blas.Uplo, t blas.Transpose, n, k int, alpha comp
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6189,13 +6486,22 @@ func (Implementation) Zsyr2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6262,10 +6568,16 @@ func (Implementation) Ztrmm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex128
@@ -6328,10 +6640,16 @@ func (Implementation) Ztrsm(s blas.Side, ul blas.Uplo, tA blas.Transpose, d blas
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
 	var _a *complex128
@@ -6376,13 +6694,22 @@ func (Implementation) Chemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex64
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6431,10 +6758,16 @@ func (Implementation) Cherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6479,13 +6812,22 @@ func (Implementation) Cher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex64
@@ -6534,13 +6876,22 @@ func (Implementation) Zhemm(s blas.Side, ul blas.Uplo, m, n int, alpha complex12
 	} else {
 		k = n
 	}
-	if lda*(k-1)+k > len(a) || lda < max(1, k) {
+	if lda < max(1, k) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, n) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(k-1)+k > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(m-1)+n > len(b) || ldb < max(1, n) {
+	if ldb*(m-1)+n > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(m-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(m-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6589,10 +6940,16 @@ func (Implementation) Zherk(ul blas.Uplo, t blas.Transpose, n, k int, alpha floa
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128
@@ -6637,13 +6994,22 @@ func (Implementation) Zher2k(ul blas.Uplo, t blas.Transpose, n, k int, alpha com
 	} else {
 		row, col = k, n
 	}
-	if lda*(row-1)+col > len(a) || lda < max(1, col) {
+	if lda < max(1, col) {
+		panic("blas: bad lda")
+	}
+	if ldb < max(1, col) {
+		panic("blas: bad ldb")
+	}
+	if ldc < max(1, n) {
+		panic("blas: bad ldc")
+	}
+	if lda*(row-1)+col > len(a) {
 		panic("blas: index of a out of range")
 	}
-	if ldb*(row-1)+col > len(b) || ldb < max(1, col) {
+	if ldb*(row-1)+col > len(b) {
 		panic("blas: index of b out of range")
 	}
-	if ldc*(n-1)+n > len(c) || ldc < max(1, n) {
+	if ldc*(n-1)+n > len(c) {
 		panic("blas: index of c out of range")
 	}
 	var _a *complex128

--- a/blas/netlib/errors.go
+++ b/blas/netlib/errors.go
@@ -21,11 +21,16 @@ const (
 	badTranspose = "blas: illegal transpose"
 	badDiag      = "blas: illegal diagonal"
 	badSide      = "blas: illegal side"
+	badFlag      = "blas: illegal rotm flag"
 
 	badLdA = "blas: bad leading dimension of A"
 	badLdB = "blas: bad leading dimension of B"
 	badLdC = "blas: bad leading dimension of C"
 
-	badX = "blas: bad length of x"
-	badY = "blas: bad length of y"
+	shortX  = "blas: insufficient length of x"
+	shortY  = "blas: insufficient length of y"
+	shortAP = "blas: insufficient length of ap"
+	shortA  = "blas: insufficient length of a"
+	shortB  = "blas: insufficient length of b"
+	shortC  = "blas: insufficient length of c"
 )

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -618,6 +618,7 @@ func sliceLength(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) 
 		"cblas_cherk", "cblas_zherk", "cblas_cher2k", "cblas_zher2k":
 		switch pname {
 		case "a":
+			// row and col have already been declared in leadingDim.
 			fmt.Fprintf(buf, `	if len(a) < lda*(row-1)+col {
 		panic(shortA)
 	}
@@ -633,6 +634,7 @@ func sliceLength(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) 
 	case "cblas_sgemm", "cblas_dgemm", "cblas_cgemm", "cblas_zgemm":
 		switch pname {
 		case "a":
+			// rowA and colA have already been declared in leadingDim.
 			fmt.Fprint(buf, `	if len(a) < lda*(rowA-1)+colA {
 		panic(shortA)
 	}

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -523,7 +523,7 @@ func rkShape(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) bool
 
 func scalShape(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) bool {
 	switch d.Name {
-	case "cblas_sscal", "cblas_dscal", "cblas_cscal", "cblas_zscal", "cblas_csscal":
+	case "cblas_sscal", "cblas_dscal", "cblas_cscal", "cblas_zscal", "cblas_csscal", "cblas_zdscal":
 	default:
 		return true
 	}
@@ -680,7 +680,7 @@ func vectorShape(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) 
 	switch d.Name {
 	case "cblas_sgbmv", "cblas_dgbmv", "cblas_cgbmv", "cblas_zgbmv",
 		"cblas_sgemv", "cblas_dgemv", "cblas_cgemv", "cblas_zgemv",
-		"cblas_sscal", "cblas_dscal", "cblas_cscal", "cblas_zscal", "cblas_csscal",
+		"cblas_sscal", "cblas_dscal", "cblas_cscal", "cblas_zscal", "cblas_csscal", "cblas_zdscal",
 		"cblas_isamax", "cblas_idamax", "cblas_icamax", "cblas_izamax",
 		"cblas_snrm2", "cblas_dnrm2", "cblas_scnrm2", "cblas_dznrm2",
 		"cblas_sasum", "cblas_dasum", "cblas_scasum", "cblas_dzasum":

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -842,19 +842,17 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *float32
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *float32
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
+		panic("blas: illegal blas.Flag value")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -862,11 +860,13 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+        var _x *float32
+	if len(x) > 0 {
+		_x = &x[0]
 	}
-	if n == 0 {
-		return
+        var _y *float32
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	pi := srotmParams{
 		flag: float32(p.Flag),
@@ -887,19 +887,17 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *float64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *float64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
+		panic("blas: illegal blas.Flag value")
+	}
+	if n == 0 {
+		return
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -907,11 +905,13 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
-		panic("blas: illegal blas.Flag value")
+        var _x *float64
+	if len(x) > 0 {
+		_x = &x[0]
 	}
-	if n == 0 {
-		return
+        var _y *float64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	pi := drotmParams{
 		flag: float64(p.Flag),
@@ -923,19 +923,14 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -943,8 +938,13 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+        var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+        var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cdotu_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotu))
 	return dotu
@@ -953,19 +953,14 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *complex64
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *complex64
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -973,8 +968,13 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+        var _x *complex64
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+        var _y *complex64
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_cdotc_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotc))
 	return dotc
@@ -983,19 +983,14 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1003,8 +998,13 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+        var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+        var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zdotu_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotu))
 	return dotu
@@ -1013,19 +1013,14 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if n < 0 {
 		panic("blas: n < 0")
 	}
-        var _x *complex128
-	if len(x) > 0 {
-		_x = &x[0]
-	}
 	if incX == 0 {
 		panic("blas: zero x index increment")
 	}
-        var _y *complex128
-	if len(y) > 0 {
-		_y = &y[0]
-	}
 	if incY == 0 {
 		panic("blas: zero y index increment")
+	}
+	if n == 0 {
+		return 0
 	}
 	if (incX > 0 && (n-1)*incX >= len(x)) || (incX < 0 && (1-n)*incX >= len(x)) {
 		panic("blas: x index out of range")
@@ -1033,8 +1028,13 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && (n-1)*incY >= len(y)) || (incY < 0 && (1-n)*incY >= len(y)) {
 		panic("blas: y index out of range")
 	}
-	if n == 0 {
-		return 0
+        var _x *complex128
+	if len(x) > 0 {
+		_x = &x[0]
+	}
+        var _y *complex128
+	if len(y) > 0 {
+		_y = &y[0]
 	}
 	C.cblas_zdotc_sub(C.int(n), unsafe.Pointer(_x), C.int(incX), unsafe.Pointer(_y), C.int(incY), unsafe.Pointer(&dotc))
 	return dotc

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -517,23 +517,35 @@ func noWork(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) {
 	switch d.Name {
 	case "cblas_snrm2", "cblas_dnrm2", "cblas_scnrm2", "cblas_dznrm2",
 		"cblas_sasum", "cblas_dasum", "cblas_scasum", "cblas_dzasum":
-		fmt.Fprint(buf, `	if n == 0 || incX < 0 {
+		fmt.Fprint(buf, `
+	// Quick return if possible.
+	if n == 0 || incX < 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 `)
 		return
 
 	case "cblas_sscal", "cblas_dscal", "cblas_cscal", "cblas_zscal", "cblas_csscal", "cblas_zdscal":
-		fmt.Fprint(buf, `	if n == 0 || incX < 0 {
+		fmt.Fprint(buf, `
+	// Quick return if possible.
+	if n == 0 || incX < 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 `)
 		return
 
 	case "cblas_isamax", "cblas_idamax", "cblas_icamax", "cblas_izamax":
-		fmt.Fprint(buf, `	if n == 0 || incX < 0 {
+		fmt.Fprint(buf, `
+	// Quick return if possible.
+	if n == 0 || incX < 0 {
 		return -1
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 `)
 		return
 	}
@@ -550,14 +562,22 @@ func noWork(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) {
 		}
 	}
 	if !hasM {
-		fmt.Fprintf(buf, `	if n == 0 {
+		fmt.Fprintf(buf, `
+	// Quick return if possible.
+	if n == 0 {
 		return%s
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 `, value)
 	} else {
-		fmt.Fprintf(buf, `	if m == 0 || n == 0 {
+		fmt.Fprintf(buf, `
+	// Quick return if possible.
+	if m == 0 || n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 `)
 	}
 }
@@ -866,9 +886,13 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
 		panic(badFlag)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -911,9 +935,13 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if p.Flag < blas.Identity || p.Flag > blas.Diagonal {
 		panic(badFlag)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -944,9 +972,13 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -974,9 +1006,13 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1004,9 +1040,13 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}
@@ -1034,9 +1074,13 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if incY == 0 {
 		panic(zeroIncY)
 	}
+
+	// Quick return if possible.
 	if n == 0 {
 		return 0
 	}
+
+	// For zero matrix size the following slice length checks are trivially satisfied.
 	if (incX > 0 && len(x) <= (n-1)*incX) || (incX < 0 && len(x) <= (1-n)*incX) {
 		panic(shortX)
 	}

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -761,9 +761,9 @@ func address(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) {
 			}
 		}
 		fmt.Fprintf(buf, `	var _%[1]s *%[2]s
-        if len(%[1]s) > 0 {
-                _%[1]s = &%[1]s[0]
-        }
+	if len(%[1]s) > 0 {
+		_%[1]s = &%[1]s[0]
+	}
 `, n, t)
 	}
 	return
@@ -875,11 +875,11 @@ func (Implementation) Srotm(n int, x []float32, incX int, y []float32, incY int,
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *float32
+	var _x *float32
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *float32
+	var _y *float32
 	if len(y) > 0 {
 		_y = &y[0]
 	}
@@ -920,11 +920,11 @@ func (Implementation) Drotm(n int, x []float64, incX int, y []float64, incY int,
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *float64
+	var _x *float64
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *float64
+	var _y *float64
 	if len(y) > 0 {
 		_y = &y[0]
 	}
@@ -953,11 +953,11 @@ func (Implementation) Cdotu(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *complex64
+	var _x *complex64
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *complex64
+	var _y *complex64
 	if len(y) > 0 {
 		_y = &y[0]
 	}
@@ -983,11 +983,11 @@ func (Implementation) Cdotc(n int, x []complex64, incX int, y []complex64, incY 
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *complex64
+	var _x *complex64
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *complex64
+	var _y *complex64
 	if len(y) > 0 {
 		_y = &y[0]
 	}
@@ -1013,11 +1013,11 @@ func (Implementation) Zdotu(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *complex128
+	var _x *complex128
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *complex128
+	var _y *complex128
 	if len(y) > 0 {
 		_y = &y[0]
 	}
@@ -1043,11 +1043,11 @@ func (Implementation) Zdotc(n int, x []complex128, incX int, y []complex128, inc
 	if (incY > 0 && len(y) <= (n-1)*incY) || (incY < 0 && len(y) <= (1-n)*incY) {
 		panic(shortY)
 	}
-        var _x *complex128
+	var _x *complex128
 	if len(x) > 0 {
 		_x = &x[0]
 	}
-        var _y *complex128
+	var _y *complex128
 	if len(y) > 0 {
 		_y = &y[0]
 	}

--- a/blas/netlib/generate_blas.go
+++ b/blas/netlib/generate_blas.go
@@ -253,8 +253,8 @@ func goSignature(buf *bytes.Buffer, d binding.Declaration, docs map[string][]*as
 
 func parameterChecks(buf *bytes.Buffer, d binding.Declaration, rules []func(*bytes.Buffer, binding.Declaration, binding.Parameter) bool) {
 	done := make(map[int]bool)
-	for _, p := range d.Parameters() {
-		for i, r := range rules {
+	for i, r := range rules {
+		for _, p := range d.Parameters() {
 			if done[i] {
 				continue
 			}
@@ -289,10 +289,12 @@ var parameterCheckRules = []func(*bytes.Buffer, binding.Declaration, binding.Par
 	uplo,
 	diag,
 	side,
-
 	shape,
-	apShape,
 	zeroInc,
+
+	noWork,
+
+	apShape,
 	sidedShape,
 	mvShape,
 	rkShape,
@@ -304,8 +306,6 @@ var parameterCheckRules = []func(*bytes.Buffer, binding.Declaration, binding.Par
 	othersShape,
 
 	address,
-
-	noWork,
 }
 
 func amaxShape(buf *bytes.Buffer, d binding.Declaration, p binding.Parameter) bool {


### PR DESCRIPTION
This got bigger than expected. I looked at the code generation to see how and where to change the panic strings and I noticed a few things that could be polished and one thing led to another and this is the result.

There are now fewer parameter check functions and some of them got much bigger but I think that it is easier to see now how the code is generated. The bool that was previously returned made this not so easy.

Most of the changes in the output `blas.go` should be just text movement with some refinement here and there. It is best reviewed commit by commit.

Please take a look.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
