### PR TITLE
travis: remove redundant go get invocations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ matrix:
 before_install:
  # Required for format check.
  - go get golang.org/x/tools/cmd/goimports
- # Required for code get checks.
- - go mod download gonum.org/v1/gonum || true
  # Required for imports check.
  - go get gonum.org/v1/tools/cmd/check-imports
  # Required for copyright header check.

--- a/.travis/linux/install.sh
+++ b/.travis/linux/install.sh
@@ -4,13 +4,9 @@ set -ex
 # prior to more specific installation commands for a particular blas library.
 go get golang.org/x/tools/cmd/cover
 go get github.com/mattn/goveralls
-go get gonum.org/v1/gonum/blas
-go get gonum.org/v1/gonum/lapack
-go get gonum.org/v1/gonum/floats
 
 # Repositories for code generation.
 go get modernc.org/cc
-go get gonum.org/v1/netlib/internal/binding
 
 # travis compiles commands in script and then executes in bash.  By adding
 # set -e we are changing the travis build script's behavior, and the set


### PR DESCRIPTION
Please take a look.

The previous case caused the version of gonum/gonum to be upgraded which results in version skew and potential test failure when doing code generation checks.

<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies Gonum to _____."
-->
