### PR TITLE
Update the version of gonum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237 // indirect
 	golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495
-	gonum.org/v1/gonum v0.8.1-0.20200930085651-eea0b5cb5cc9
+	gonum.org/v1/gonum v0.8.2
 	modernc.org/cc v1.0.0
 	modernc.org/golex v1.0.0 // indirect
 	modernc.org/mathutil v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ gonum.org/v1/gonum v0.8.1-0.20200930085651-eea0b5cb5cc9 h1:EhU7NlbjQJrI6umH0+aSO
 gonum.org/v1/gonum v0.8.1-0.20200930085651-eea0b5cb5cc9/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.8.1 h1:wGtP3yGpc5mCLOLeTeBdjeui9oZSz5De0eOjMLC/QuQ=
 gonum.org/v1/gonum v0.8.1/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
+gonum.org/v1/gonum v0.8.2 h1:CCXrcPKiGGotvnN6jfUsKk4rRqm7q09/YbKb5xCEvtM=
+gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 modernc.org/cc v1.0.0 h1:nPibNuDEx6tvYrUAtvDTTw98rx5juGsa5zuDnKwEEQQ=


### PR DESCRIPTION
These two packages have a circular dependency on each other. This
is making it hard to update these two modules further upstream in
the import chain.

